### PR TITLE
[MacOS] Handle receiving URL as platform-specific event

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -117,6 +117,19 @@ pub enum Event<'a, T: 'static> {
     /// gets emitted. You generally want to treat this as an "do on quit" event.
     LoopDestroyed,
 
+    /// Emitted when the event loop receives an event that only occurs on some specific platform.
+    PlatformSpecific(PlatformSpecific),
+}
+
+/// Describes an event from some specific platform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlatformSpecific {
+    MacOS(MacOS),
+}
+
+/// Describes an event that only happens in `MacOS`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacOS {
     ReceivedUrl(String),
 }
 
@@ -140,7 +153,7 @@ impl<T: Clone> Clone for Event<'static, T> {
             LoopDestroyed => LoopDestroyed,
             Suspended => Suspended,
             Resumed => Resumed,
-            ReceivedUrl(url) => ReceivedUrl(url.clone()),
+            PlatformSpecific(event) => PlatformSpecific(event.clone()),
         }
     }
 }
@@ -159,7 +172,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Ok(LoopDestroyed),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
-            ReceivedUrl(url) => Ok(ReceivedUrl(url)),
+            PlatformSpecific(event) => Ok(PlatformSpecific(event)),
         }
     }
 
@@ -180,7 +193,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Some(LoopDestroyed),
             Suspended => Some(Suspended),
             Resumed => Some(Resumed),
-            ReceivedUrl(url) => Some(ReceivedUrl(url)),
+            PlatformSpecific(event) => Some(PlatformSpecific(event)),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -116,6 +116,8 @@ pub enum Event<'a, T: 'static> {
     /// This is irreversable - if this event is emitted, it is guaranteed to be the last event that
     /// gets emitted. You generally want to treat this as an "do on quit" event.
     LoopDestroyed,
+
+    ReceivedUrl(String),
 }
 
 impl<T: Clone> Clone for Event<'static, T> {
@@ -138,6 +140,7 @@ impl<T: Clone> Clone for Event<'static, T> {
             LoopDestroyed => LoopDestroyed,
             Suspended => Suspended,
             Resumed => Resumed,
+            ReceivedUrl(url) => ReceivedUrl(url.clone()),
         }
     }
 }
@@ -156,6 +159,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Ok(LoopDestroyed),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
+            ReceivedUrl(url) => Ok(ReceivedUrl(url)),
         }
     }
 
@@ -176,6 +180,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Some(LoopDestroyed),
             Suspended => Some(Suspended),
             Resumed => Some(Resumed),
+            ReceivedUrl(url) => Some(ReceivedUrl(url)),
         }
     }
 }


### PR DESCRIPTION
Allows receiving URLs on MacOS. This also introduces a new enum (`PlatformSpecific`) for events that are specific to a platform.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
