### PR TITLE
Use proposed fullscreen options in `window_delegate`

### DIFF
--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use cocoa::{
-    appkit::{self, NSApplicationPresentationOptions, NSView, NSWindow},
+    appkit::{self, NSView, NSWindow},
     base::{id, nil},
     foundation::NSUInteger,
 };
@@ -485,20 +485,9 @@ extern "C" fn window_will_use_fullscreen_presentation_options(
     _this: &Object,
     _: Sel,
     _: id,
-    _proposed_options: NSUInteger,
+    proposed_options: NSUInteger,
 ) -> NSUInteger {
-    // Generally, games will want to disable the menu bar and the dock. Ideally,
-    // this would be configurable by the user. Unfortunately because of our
-    // `CGShieldingWindowLevel() + 1` hack (see `set_fullscreen`), our window is
-    // placed on top of the menu bar in exclusive fullscreen mode. This looks
-    // broken so we always disable the menu bar in exclusive fullscreen. We may
-    // still want to make this configurable for borderless fullscreen. Right now
-    // we don't, for consistency. If we do, it should be documented that the
-    // user-provided options are ignored in exclusive fullscreen.
-    (NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
-        | NSApplicationPresentationOptions::NSApplicationPresentationHideDock
-        | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar)
-        .bits()
+    proposed_options
 }
 
 /// Invoked when entered fullscreen


### PR DESCRIPTION
Fixes the menu bar being completely hidden when fullscreen is enabled on macOS, even if you move the cursor to the top edge of the screen.