### PR TITLE
Menu

### DIFF
--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -1,0 +1,50 @@
+use simple_logger::SimpleLogger;
+use winit::{event::{Event, ModifiersState, WindowEvent}, event_loop::{ControlFlow, EventLoop}, window::{Menu, WindowBuilder, Hotkey}};
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new();
+
+    let mut menu = Menu::new();
+    menu.add_item(0, "One", None);
+    menu.add_item(1, "Two", None);
+    menu.add_separator();
+    
+    let mut sub_menu = Menu::new();
+    sub_menu.add_item(2, "Sub One", Hotkey::new(ModifiersState::ALT, winit::event::VirtualKeyCode::F1));
+    sub_menu.add_item(3, "Sub Two", Hotkey::new(ModifiersState::ALT, winit::event::VirtualKeyCode::F2));
+    sub_menu.add_separator();
+    sub_menu.add_item(4, "Sub Three", Hotkey::new(ModifiersState::empty(), winit::event::VirtualKeyCode::F5));
+
+    menu.add_dropdown("Three", sub_menu);
+
+    let window = WindowBuilder::new()
+        .with_menu(Some(menu))
+        .with_title("A fantastic window!")
+        .with_inner_size(winit::dpi::LogicalSize::new(300.0, 128.0))
+        .build(&event_loop)
+        .unwrap();
+
+        window.request_redraw();
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            Event::MainEventsCleared => {
+                window.request_redraw();
+            }
+            Event::WindowEvent{
+                event: WindowEvent::MenuEntryActivated(id),
+                window_id,
+            } if window_id == window.id() => {
+                println!("Activated: {}", id);
+            },
+            _ => (),
+        }
+    });
+}

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -1,5 +1,9 @@
 use simple_logger::SimpleLogger;
-use winit::{event::{Event, ModifiersState, WindowEvent}, event_loop::{ControlFlow, EventLoop}, window::{Menu, WindowBuilder, Hotkey}};
+use winit::{
+    event::{Event, ModifiersState, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::{Hotkey, Menu, WindowBuilder},
+};
 
 fn main() {
     SimpleLogger::new().init().unwrap();
@@ -8,7 +12,11 @@ fn main() {
     let mut main = Menu::default();
 
     let mut first = Menu::new();
-    first.add_item(0, "One", Hotkey::new(ModifiersState::CTRL, winit::event::VirtualKeyCode::Return));
+    first.add_item(
+        0,
+        "One",
+        Hotkey::new(ModifiersState::CTRL, winit::event::VirtualKeyCode::Return),
+    );
 
     main.add_dropdown("First", first);
     let window = WindowBuilder::new()
@@ -17,11 +25,11 @@ fn main() {
         .with_inner_size(winit::dpi::LogicalSize::new(300.0, 128.0))
         .build(&event_loop)
         .unwrap();
-        
-        event_loop.run(move |event, _, control_flow| {
-            *control_flow = ControlFlow::Wait;
-            
-            match event {
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
@@ -29,12 +37,12 @@ fn main() {
             Event::MainEventsCleared => {
                 window.request_redraw();
             }
-            Event::WindowEvent{
+            Event::WindowEvent {
                 event: WindowEvent::MenuEntryActivated(id),
                 ..
             } => {
                 println!("Activated: {}", id);
-            },
+            }
             _ => (),
         }
     });

--- a/examples/menu.rs
+++ b/examples/menu.rs
@@ -5,32 +5,23 @@ fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let mut menu = Menu::new();
-    menu.add_item(0, "One", None);
-    menu.add_item(1, "Two", None);
-    menu.add_separator();
-    
-    let mut sub_menu = Menu::new();
-    sub_menu.add_item(2, "Sub One", Hotkey::new(ModifiersState::ALT, winit::event::VirtualKeyCode::F1));
-    sub_menu.add_item(3, "Sub Two", Hotkey::new(ModifiersState::ALT, winit::event::VirtualKeyCode::F2));
-    sub_menu.add_separator();
-    sub_menu.add_item(4, "Sub Three", Hotkey::new(ModifiersState::empty(), winit::event::VirtualKeyCode::F5));
+    let mut main = Menu::default();
 
-    menu.add_dropdown("Three", sub_menu);
+    let mut first = Menu::new();
+    first.add_item(0, "One", Hotkey::new(ModifiersState::CTRL, winit::event::VirtualKeyCode::Return));
 
+    main.add_dropdown("First", first);
     let window = WindowBuilder::new()
-        .with_menu(Some(menu))
-        .with_title("A fantastic window!")
+        .with_menu(Some(main))
+        .with_title("A fantastic window (with a menu)!")
         .with_inner_size(winit::dpi::LogicalSize::new(300.0, 128.0))
         .build(&event_loop)
         .unwrap();
-
-        window.request_redraw();
-
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
-
-        match event {
+        
+        event_loop.run(move |event, _, control_flow| {
+            *control_flow = ControlFlow::Wait;
+            
+            match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
@@ -40,8 +31,8 @@ fn main() {
             }
             Event::WindowEvent{
                 event: WindowEvent::MenuEntryActivated(id),
-                window_id,
-            } if window_id == window.id() => {
+                ..
+            } => {
                 println!("Activated: {}", id);
             },
             _ => (),

--- a/src/event.rs
+++ b/src/event.rs
@@ -370,6 +370,11 @@ pub enum WindowEvent<'a> {
     ///
     /// At the moment this is only supported on Windows.
     ThemeChanged(Theme),
+
+    /// An entry in the active menu has been activated.
+    ///
+    /// The event contains the `id` of the entry (given by the user when it was created).
+    MenuEntryActivated(isize),
 }
 
 impl Clone for WindowEvent<'static> {
@@ -458,7 +463,8 @@ impl Clone for WindowEvent<'static> {
             ThemeChanged(theme) => ThemeChanged(theme.clone()),
             ScaleFactorChanged { .. } => {
                 unreachable!("Static event can't be about scale factor changing")
-            }
+            },
+            MenuEntryActivated(id) => MenuEntryActivated(*id)
         };
     }
 }
@@ -543,6 +549,7 @@ impl<'a> WindowEvent<'a> {
             Touch(touch) => Some(Touch(touch)),
             ThemeChanged(theme) => Some(ThemeChanged(theme)),
             ScaleFactorChanged { .. } => None,
+            MenuEntryActivated(id) => Some(MenuEntryActivated(id)),
         }
     }
 }
@@ -986,6 +993,191 @@ pub enum VirtualKeyCode {
     Copy,
     Paste,
     Cut,
+}
+
+impl From<VirtualKeyCode> for String{
+    fn from(key: VirtualKeyCode) -> Self {
+        let converted = match key{
+            VirtualKeyCode::Key1 => "1",
+            VirtualKeyCode::Key2 => "2",
+            VirtualKeyCode::Key3 => "3",
+            VirtualKeyCode::Key4 => "4",
+            VirtualKeyCode::Key5 => "5",
+            VirtualKeyCode::Key6 => "6",
+            VirtualKeyCode::Key7 => "7",
+            VirtualKeyCode::Key8 => "8",
+            VirtualKeyCode::Key9 => "9",
+            VirtualKeyCode::Key0 => "0",
+
+            VirtualKeyCode::A => "A",
+            VirtualKeyCode::B => "B",
+            VirtualKeyCode::C => "C",
+            VirtualKeyCode::D => "D",
+            VirtualKeyCode::E => "E",
+            VirtualKeyCode::F => "F",
+            VirtualKeyCode::G => "G",
+            VirtualKeyCode::H => "H",
+            VirtualKeyCode::I => "I",
+            VirtualKeyCode::J => "J",
+            VirtualKeyCode::K => "K",
+            VirtualKeyCode::L => "L",
+            VirtualKeyCode::M => "M",
+            VirtualKeyCode::N => "N",
+            VirtualKeyCode::O => "O",
+            VirtualKeyCode::P => "P",
+            VirtualKeyCode::Q => "Q",
+            VirtualKeyCode::R => "R",
+            VirtualKeyCode::S => "S",
+            VirtualKeyCode::T => "T",
+            VirtualKeyCode::U => "U",
+            VirtualKeyCode::V => "V",
+            VirtualKeyCode::W => "W",
+            VirtualKeyCode::X => "X",
+            VirtualKeyCode::Y => "Y",
+            VirtualKeyCode::Z => "Z",
+
+            VirtualKeyCode::Escape => "Esc",
+
+            VirtualKeyCode::F1 => "F1",
+            VirtualKeyCode::F2 => "F2",
+            VirtualKeyCode::F3 => "F3",
+            VirtualKeyCode::F4 => "F4",
+            VirtualKeyCode::F5 => "F5",
+            VirtualKeyCode::F6 => "F6",
+            VirtualKeyCode::F7 => "F7",
+            VirtualKeyCode::F8 => "F8",
+            VirtualKeyCode::F9 => "F9",
+            VirtualKeyCode::F10 => "F10",
+            VirtualKeyCode::F11 => "F11",
+            VirtualKeyCode::F12 => "F12",
+            VirtualKeyCode::F13 => "F13",
+            VirtualKeyCode::F14 => "F14",
+            VirtualKeyCode::F15 => "F15",
+            VirtualKeyCode::F16 => "F16",
+            VirtualKeyCode::F17 => "F17",
+            VirtualKeyCode::F18 => "F18",
+            VirtualKeyCode::F19 => "F19",
+            VirtualKeyCode::F20 => "F20",
+            VirtualKeyCode::F21 => "F21",
+            VirtualKeyCode::F22 => "F22",
+            VirtualKeyCode::F23 => "F23",
+            VirtualKeyCode::F24 => "F24",
+
+            VirtualKeyCode::Snapshot => "PrtScn",
+            VirtualKeyCode::Scroll => "ScrLk",
+            VirtualKeyCode::Pause => "Pause",
+
+            VirtualKeyCode::Insert => "Ins",
+            VirtualKeyCode::Home => "Home",
+            VirtualKeyCode::Delete => "Del",
+            VirtualKeyCode::End => "End",
+            VirtualKeyCode::PageDown => "PgDn",
+            VirtualKeyCode::PageUp => "PgUp",
+
+            VirtualKeyCode::Left => "Left",
+            VirtualKeyCode::Up => "Up",
+            VirtualKeyCode::Right => "Right",
+            VirtualKeyCode::Down => "Down",
+
+            VirtualKeyCode::Back => "Backspace",
+            VirtualKeyCode::Return => "Enter",
+            VirtualKeyCode::Space => "Space",
+
+            VirtualKeyCode::Compose => "Compose",
+
+            VirtualKeyCode::Caret => "^",
+
+            VirtualKeyCode::Numlock => "NumLk",
+            VirtualKeyCode::Numpad0 => "Numpad0",
+            VirtualKeyCode::Numpad1 => "Numpad1",
+            VirtualKeyCode::Numpad2 => "Numpad2",
+            VirtualKeyCode::Numpad3 => "Numpad3",
+            VirtualKeyCode::Numpad4 => "Numpad4",
+            VirtualKeyCode::Numpad5 => "Numpad5",
+            VirtualKeyCode::Numpad6 => "Numpad6",
+            VirtualKeyCode::Numpad7 => "Numpad7",
+            VirtualKeyCode::Numpad8 => "Numpad8",
+            VirtualKeyCode::Numpad9 => "Numpad9",
+            VirtualKeyCode::NumpadAdd => "+",
+            VirtualKeyCode::NumpadDivide => "/",
+            VirtualKeyCode::NumpadDecimal => ".",
+            VirtualKeyCode::NumpadComma => ",",
+            VirtualKeyCode::NumpadEnter => "Enter",
+            VirtualKeyCode::NumpadEquals => "=",
+            VirtualKeyCode::NumpadMultiply => "*",
+            VirtualKeyCode::NumpadSubtract => "-",
+
+            VirtualKeyCode::AbntC1 => "AbntC1",
+            VirtualKeyCode::AbntC2 => "AbntC2",
+            VirtualKeyCode::Apostrophe => "'",
+            VirtualKeyCode::Apps => "Apps",
+            VirtualKeyCode::Asterisk => "*",
+            VirtualKeyCode::At => "At",
+            VirtualKeyCode::Ax => "Ax",
+            VirtualKeyCode::Backslash => "\\",
+            VirtualKeyCode::Calculator => "Calculator",
+            VirtualKeyCode::Capital => "CapsLock",
+            VirtualKeyCode::Colon => ";",
+            VirtualKeyCode::Comma => ",",
+            VirtualKeyCode::Convert => "Convert",
+            VirtualKeyCode::Equals => "=",
+            VirtualKeyCode::Grave => "Grave",
+            VirtualKeyCode::Kana => "Kana",
+            VirtualKeyCode::Kanji => "Kanji",
+            VirtualKeyCode::LAlt => "LAlt",
+            VirtualKeyCode::LBracket => "LBracket",
+            VirtualKeyCode::LControl => "LControl",
+            VirtualKeyCode::LShift => "LShift",
+            VirtualKeyCode::LWin => "LWin",
+            VirtualKeyCode::Mail => "Mail",
+            VirtualKeyCode::MediaSelect => "MediaSelect",
+            VirtualKeyCode::MediaStop => "MediaStop",
+            VirtualKeyCode::Minus => "Minus",
+            VirtualKeyCode::Mute => "Mute",
+            VirtualKeyCode::MyComputer => "MyComputer",
+
+            VirtualKeyCode::NavigateForward => "Next",
+            VirtualKeyCode::NavigateBackward => "Prior",
+
+            VirtualKeyCode::NextTrack => "NextTrack",
+            VirtualKeyCode::NoConvert => "NoConvert",
+            VirtualKeyCode::OEM102 => "OEM102",
+            VirtualKeyCode::Period => ".",
+            VirtualKeyCode::PlayPause => "PlayPause",
+            VirtualKeyCode::Plus => "Plus",
+            VirtualKeyCode::Power => "Power",
+            VirtualKeyCode::PrevTrack => "PrevTrack",
+            VirtualKeyCode::RAlt => "RAlt",
+            VirtualKeyCode::RBracket => "RBracket",
+            VirtualKeyCode::RControl => "RControl",
+            VirtualKeyCode::RShift => "RShift",
+            VirtualKeyCode::RWin => "RWin",
+            VirtualKeyCode::Semicolon => "Semicolon",
+            VirtualKeyCode::Slash => "Slash",
+            VirtualKeyCode::Sleep => "Sleep",
+            VirtualKeyCode::Stop => "Stop",
+            VirtualKeyCode::Sysrq => "Sysrq",
+            VirtualKeyCode::Tab => "Tab",
+            VirtualKeyCode::Underline => "_",
+            VirtualKeyCode::Unlabeled => "Unlabeled",
+            VirtualKeyCode::VolumeDown => "VolDown",
+            VirtualKeyCode::VolumeUp => "VolUp",
+            VirtualKeyCode::Wake => "Wake",
+            VirtualKeyCode::WebBack => "WebBack",
+            VirtualKeyCode::WebFavorites => "WebFavorites",
+            VirtualKeyCode::WebForward => "WebForward",
+            VirtualKeyCode::WebHome => "WebHome",
+            VirtualKeyCode::WebRefresh => "WebRefresh",
+            VirtualKeyCode::WebSearch => "WebSearch",
+            VirtualKeyCode::WebStop => "WebStop",
+            VirtualKeyCode::Yen => "Yen",
+            VirtualKeyCode::Copy => "Copy",
+            VirtualKeyCode::Paste => "Paste",
+            VirtualKeyCode::Cut => "Cut",
+        };
+
+        String::from(converted)
+    }
 }
 
 impl ModifiersState {

--- a/src/event.rs
+++ b/src/event.rs
@@ -463,8 +463,8 @@ impl Clone for WindowEvent<'static> {
             ThemeChanged(theme) => ThemeChanged(theme.clone()),
             ScaleFactorChanged { .. } => {
                 unreachable!("Static event can't be about scale factor changing")
-            },
-            MenuEntryActivated(id) => MenuEntryActivated(*id)
+            }
+            MenuEntryActivated(id) => MenuEntryActivated(*id),
         };
     }
 }
@@ -995,9 +995,9 @@ pub enum VirtualKeyCode {
     Cut,
 }
 
-impl From<VirtualKeyCode> for String{
+impl From<VirtualKeyCode> for String {
     fn from(key: VirtualKeyCode) -> Self {
-        let converted = match key{
+        let converted = match key {
             VirtualKeyCode::Key1 => "1",
             VirtualKeyCode::Key2 => "2",
             VirtualKeyCode::Key3 => "3",

--- a/src/event.rs
+++ b/src/event.rs
@@ -374,7 +374,7 @@ pub enum WindowEvent<'a> {
     /// An entry in the active menu has been activated.
     ///
     /// The event contains the `id` of the entry (given by the user when it was created).
-    MenuEntryActivated(isize),
+    MenuEntryActivated(u32),
 }
 
 impl Clone for WindowEvent<'static> {

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -186,28 +186,12 @@ pub trait EventLoopExtMacOS {
     /// This function only takes effect if it's called before calling [`run`](crate::event_loop::EventLoop::run) or
     /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
     fn set_activation_policy(&mut self, activation_policy: ActivationPolicy);
-
-    /// Used to prevent a default menubar menu from getting created
-    ///
-    /// The default menu creation is enabled by default.
-    ///
-    /// This function only takes effect if it's called before calling
-    /// [`run`](crate::event_loop::EventLoop::run) or
-    /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
-    fn enable_default_menu_creation(&mut self, enable: bool);
 }
 impl<T> EventLoopExtMacOS for EventLoop<T> {
     #[inline]
     fn set_activation_policy(&mut self, activation_policy: ActivationPolicy) {
         unsafe {
             get_aux_state_mut(&**self.event_loop.delegate).activation_policy = activation_policy;
-        }
-    }
-
-    #[inline]
-    fn enable_default_menu_creation(&mut self, enable: bool) {
-        unsafe {
-            get_aux_state_mut(&**self.event_loop.delegate).create_default_menu = enable;
         }
     }
 }

--- a/src/platform_impl/android/menu.rs
+++ b/src/platform_impl/android/menu.rs
@@ -1,0 +1,62 @@
+use crate::event::{ModifiersState, VirtualKeyCode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Hotkey {
+    modifiers: ModifiersState,
+    key: VirtualKeyCode,
+}
+
+impl Hotkey {
+    pub fn new(modifiers: ModifiersState, key: VirtualKeyCode) -> Self {
+        Self { modifiers, key }
+    }
+}
+
+impl From<Hotkey> for String {
+    fn from(hotkey: Hotkey) -> Self {
+        let mut string = String::new();
+        if hotkey.modifiers.logo() {
+            string.push_str("Super+");
+        }
+        if hotkey.modifiers.ctrl() {
+            string.push_str("Ctrl+");
+        }
+        if hotkey.modifiers.shift() {
+            string.push_str("Shift+");
+        }
+        if hotkey.modifiers.alt() {
+            string.push_str("Alt+");
+        }
+
+        string.push_str(&String::from(hotkey.key));
+
+        string
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Menu;
+
+impl Menu {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn add_item<S: Into<String>, H: Into<Option<Hotkey>>>(
+        &mut self,
+        _id: usize,
+        _name: S,
+        _key: H,
+    ) {
+    }
+
+    pub fn add_dropdown<S: Into<String>>(&mut self, _name: S, _menu: Menu) {}
+
+    pub fn add_separator(&mut self) {}
+}
+
+impl Default for Menu {
+    fn default() -> Self {
+        Menu::new()
+    }
+}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -18,6 +18,10 @@ use std::{
     time::{Duration, Instant},
 };
 
+mod menu;
+
+pub use menu::{Hotkey, Menu};
+
 lazy_static! {
     static ref CONFIG: RwLock<Configuration> = RwLock::new(Configuration::new());
 }
@@ -492,6 +496,9 @@ impl Window {
     pub fn set_outer_position(&self, _position: Position) {
         // no effect
     }
+
+    #[inline]
+    pub fn set_menu(&self, _menu: Option<Menu>) {}
 
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         self.outer_size()

--- a/src/platform_impl/ios/menu.rs
+++ b/src/platform_impl/ios/menu.rs
@@ -1,0 +1,62 @@
+use crate::event::{ModifiersState, VirtualKeyCode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Hotkey {
+    modifiers: ModifiersState,
+    key: VirtualKeyCode,
+}
+
+impl Hotkey {
+    pub fn new(modifiers: ModifiersState, key: VirtualKeyCode) -> Self {
+        Self { modifiers, key }
+    }
+}
+
+impl From<Hotkey> for String {
+    fn from(hotkey: Hotkey) -> Self {
+        let mut string = String::new();
+        if hotkey.modifiers.logo() {
+            string.push_str("Super+");
+        }
+        if hotkey.modifiers.ctrl() {
+            string.push_str("Ctrl+");
+        }
+        if hotkey.modifiers.shift() {
+            string.push_str("Shift+");
+        }
+        if hotkey.modifiers.alt() {
+            string.push_str("Alt+");
+        }
+
+        string.push_str(&String::from(hotkey.key));
+
+        string
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Menu;
+
+impl Menu {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn add_item<S: Into<String>, H: Into<Option<Hotkey>>>(
+        &mut self,
+        _id: usize,
+        _name: S,
+        _key: H,
+    ) {
+    }
+
+    pub fn add_dropdown<S: Into<String>>(&mut self, _name: S, _menu: Menu) {}
+
+    pub fn add_separator(&mut self) {}
+}
+
+impl Default for Menu {
+    fn default() -> Self {
+        Menu::new()
+    }
+}

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -71,6 +71,7 @@ macro_rules! assert_main_thread {
 mod app_state;
 mod event_loop;
 mod ffi;
+mod menu;
 mod monitor;
 mod view;
 mod window;
@@ -79,6 +80,7 @@ use std::fmt;
 
 pub use self::{
     event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget},
+    menu::{Hotkey, Menu},
     monitor::{MonitorHandle, VideoMode},
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},
 };

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -20,7 +20,7 @@ use crate::{
             id, CGFloat, CGPoint, CGRect, CGSize, UIEdgeInsets, UIInterfaceOrientationMask,
             UIRectEdge, UIScreenOverscanCompensation,
         },
-        monitor, view, EventLoopWindowTarget, MonitorHandle,
+        monitor, view, EventLoopWindowTarget, Menu, MonitorHandle,
     },
     window::{
         CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
@@ -118,6 +118,9 @@ impl Inner {
             let () = msg_send![self.window, setBounds: bounds];
         }
     }
+
+    #[inline]
+    pub fn set_menu(&self, _menu: Option<Menu>) {}
 
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         unsafe {

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -1,5 +1,6 @@
 use crate::event::{ModifiersState, VirtualKeyCode};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Hotkey {
     modifiers: ModifiersState,
     key: VirtualKeyCode,

--- a/src/platform_impl/linux/menu.rs
+++ b/src/platform_impl/linux/menu.rs
@@ -1,0 +1,61 @@
+use crate::event::{ModifiersState, VirtualKeyCode};
+
+pub struct Hotkey {
+    modifiers: ModifiersState,
+    key: VirtualKeyCode,
+}
+
+impl Hotkey {
+    pub fn new(modifiers: ModifiersState, key: VirtualKeyCode) -> Self {
+        Self { modifiers, key }
+    }
+}
+
+impl From<Hotkey> for String {
+    fn from(hotkey: Hotkey) -> Self {
+        let mut string = String::new();
+        if hotkey.modifiers.logo() {
+            string.push_str("Super+");
+        }
+        if hotkey.modifiers.ctrl() {
+            string.push_str("Ctrl+");
+        }
+        if hotkey.modifiers.shift() {
+            string.push_str("Shift+");
+        }
+        if hotkey.modifiers.alt() {
+            string.push_str("Alt+");
+        }
+
+        string.push_str(&String::from(hotkey.key));
+
+        string
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Menu;
+
+impl Menu {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn add_item<S: Into<String>, H: Into<Option<Hotkey>>>(
+        &mut self,
+        _id: usize,
+        _name: S,
+        _key: H,
+    ) {
+    }
+
+    pub fn add_dropdown<S: Into<String>>(&mut self, _name: S, _menu: Menu) {}
+
+    pub fn add_separator(&mut self) {}
+}
+
+impl Default for Menu {
+    fn default() -> Self {
+        Menu::new()
+    }
+}

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -40,6 +40,10 @@ pub mod wayland;
 #[cfg(feature = "x11")]
 pub mod x11;
 
+mod menu;
+
+pub use menu::{Hotkey, Menu};
+
 /// Environment variable specifying which backend should be used on unix platform.
 ///
 /// Legal values are x11 and wayland. If this variable is set only the named backend
@@ -403,6 +407,9 @@ impl Window {
     pub fn set_decorations(&self, decorations: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_decorations(decorations))
     }
+
+    #[inline]
+    pub fn set_menu(&self, _menu: Option<Menu>) {}
 
     #[inline]
     pub fn set_always_on_top(&self, _always_on_top: bool) {

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -158,11 +158,16 @@ extern "C" fn did_finish_launching(this: &Object, _: Sel, _: id) {
 }
 
 extern "C" fn handle_menu(_this: &Object, _cmd: Sel, item: id) {
+    use std::convert::TryFrom;
+
     unsafe {
-        let id = msg_send![item, tag];
-        AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
-            window_id: WindowId(window::Id(0)),
-            event: WindowEvent::MenuEntryActivated(id),
-        }));
+        let id: isize = msg_send![item, tag];
+
+        if let Ok(id) = u32::try_from(id) {
+            AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
+                window_id: WindowId(window::Id(0)),
+                event: WindowEvent::MenuEntryActivated(id),
+            }));
+        }
     }
 }

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,6 +1,8 @@
-use crate::event::{Event, MacOS, PlatformSpecific};
+use crate::event::{Event, MacOS, PlatformSpecific, WindowEvent};
 use crate::platform::macos::ActivationPolicy;
-use crate::platform_impl::platform::{app_state::AppState, event::EventWrapper};
+use crate::platform_impl::platform::{app_state::AppState, event::EventWrapper, window};
+use crate::window::WindowId;
+
 use cocoa::base::id;
 use objc::{
     declare::ClassDecl,
@@ -50,7 +52,7 @@ lazy_static! {
         );
         decl.add_method(
             sel!(handle_menu:),
-            handle_menu as extern "C" fn(&Object, Sel, id)
+            handle_menu as extern "C" fn(&Object, Sel, id),
         );
         decl.add_ivar::<*mut c_void>(AUX_DELEGATE_STATE_NAME);
         decl.add_method(
@@ -155,10 +157,10 @@ extern "C" fn did_finish_launching(this: &Object, _: Sel, _: id) {
     trace!("Completed `applicationDidFinishLaunching`");
 }
 
-extern "C" fn handle_menu(_this: &Object, _cmd: Sel, item: id){
-    unsafe{
+extern "C" fn handle_menu(_this: &Object, _cmd: Sel, item: id) {
+    unsafe {
         let id = msg_send![item, tag];
-        AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent{
+        AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
             window_id: WindowId(window::Id(0)),
             event: WindowEvent::MenuEntryActivated(id),
         }));

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -32,7 +32,6 @@ use crate::{
         platform::{
             event::{EventProxy, EventWrapper},
             event_loop::{post_dummy_event, PanicInfo},
-            menu,
             observer::{CFRunLoopGetMain, CFRunLoopWakeUp, EventLoopWaker},
             util::{IdRef, Never},
             window::get_window_id,
@@ -290,12 +289,6 @@ impl AppState {
         };
         HANDLER.set_ready();
         HANDLER.waker().start();
-        let create_default_menu = unsafe { get_aux_state_mut(app_delegate).create_default_menu };
-        if create_default_menu {
-            // The menubar initialization should be before the `NewEvents` event, to allow
-            // overriding of the default menu even if it's created
-            menu::initialize();
-        }
         HANDLER.set_in_callback(true);
         HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::NewEvents(
             StartCause::Init,

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -8,6 +8,7 @@ use objc::{
     runtime::{Object, Sel},
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Hotkey {
     modifiers: ModifiersState,
     key: VirtualKeyCode,

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -1,5 +1,6 @@
+use crate::event::{ModifiersState, VirtualKeyCode};
 use super::util::IdRef;
-use cocoa::appkit::{NSApp, NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
+use cocoa::appkit::{NSEventModifierFlags, NSMenu, NSMenuItem};
 use cocoa::base::{nil, selector};
 use cocoa::foundation::{NSProcessInfo, NSString};
 use objc::{
@@ -7,92 +8,220 @@ use objc::{
     runtime::{Object, Sel},
 };
 
+pub struct Hotkey{
+    modifiers: ModifiersState,
+    key: VirtualKeyCode
+}
+
+impl Hotkey{
+    pub fn new(modifiers: ModifiersState, key: VirtualKeyCode) -> Self{
+        Self{
+            modifiers,
+            key,
+        }
+    }
+
+    fn parse(&self) -> (String, Option<NSEventModifierFlags>){
+        let key = match self.key{
+            VirtualKeyCode::Key1 => '1',
+            VirtualKeyCode::Key2 => '2',
+            VirtualKeyCode::Key3 => '3',
+            VirtualKeyCode::Key4 => '4',
+            VirtualKeyCode::Key5 => '5',
+            VirtualKeyCode::Key6 => '6',
+            VirtualKeyCode::Key7 => '7',
+            VirtualKeyCode::Key8 => '8',
+            VirtualKeyCode::Key9 => '9',
+            VirtualKeyCode::Key0 => '0',
+
+            VirtualKeyCode::A => 'a',
+            VirtualKeyCode::B => 'b',
+            VirtualKeyCode::C => 'c',
+            VirtualKeyCode::D => 'd',
+            VirtualKeyCode::E => 'e',
+            VirtualKeyCode::F => 'f',
+            VirtualKeyCode::G => 'g',
+            VirtualKeyCode::H => 'h',
+            VirtualKeyCode::I => 'i',
+            VirtualKeyCode::J => 'j',
+            VirtualKeyCode::K => 'k',
+            VirtualKeyCode::L => 'l',
+            VirtualKeyCode::M => 'm',
+            VirtualKeyCode::N => 'n',
+            VirtualKeyCode::O => 'o',
+            VirtualKeyCode::P => 'p',
+            VirtualKeyCode::Q => 'q',
+            VirtualKeyCode::R => 'r',
+            VirtualKeyCode::S => 's',
+            VirtualKeyCode::T => 't',
+            VirtualKeyCode::U => 'u',
+            VirtualKeyCode::V => 'v',
+            VirtualKeyCode::W => 'w',
+            VirtualKeyCode::X => 'x',
+            VirtualKeyCode::Y => 'y',
+            VirtualKeyCode::Z => 'z',
+
+            VirtualKeyCode::F1 => '\u{f704}',
+            VirtualKeyCode::F2 => '\u{f705}',
+            VirtualKeyCode::F3 => '\u{f706}',
+            VirtualKeyCode::F4 => '\u{f707}',
+            VirtualKeyCode::F5 => '\u{f708}',
+            VirtualKeyCode::F6 => '\u{f709}',
+            VirtualKeyCode::F7 => '\u{f70A}',
+            VirtualKeyCode::F8 => '\u{f70B}',
+            VirtualKeyCode::F9 => '\u{f70C}',
+            VirtualKeyCode::F10 => '\u{f70D}',
+            VirtualKeyCode::F11 => '\u{f70E}',
+            VirtualKeyCode::F12 => '\u{f70F}',
+            VirtualKeyCode::F13 => '\u{f710}',
+            VirtualKeyCode::F14 => '\u{f711}',
+            VirtualKeyCode::F15 => '\u{f712}',
+            VirtualKeyCode::F16 => '\u{f713}',
+            VirtualKeyCode::F17 => '\u{f714}',
+            VirtualKeyCode::F18 => '\u{f715}',
+            VirtualKeyCode::F19 => '\u{f716}',
+            VirtualKeyCode::F20 => '\u{f717}',
+            VirtualKeyCode::F21 => '\u{f718}',
+            VirtualKeyCode::F22 => '\u{f719}',
+            VirtualKeyCode::F23 => '\u{f71A}',
+            VirtualKeyCode::F24 => '\u{f71B}',
+
+            VirtualKeyCode::Snapshot => '\u{f738}',
+            VirtualKeyCode::Scroll => '\u{f72F}',
+            VirtualKeyCode::Pause => '\u{f730}',
+            VirtualKeyCode::Sysrq => '\u{f731}',
+            VirtualKeyCode::Stop => '\u{f734}',
+
+            VirtualKeyCode::Insert => '\u{f727}',
+            VirtualKeyCode::Home => '\u{f729}',
+            VirtualKeyCode::Delete => '\u{f728}',
+            VirtualKeyCode::End => '\u{f72B}',
+            VirtualKeyCode::PageDown => '\u{f72D}',
+            VirtualKeyCode::PageUp => '\u{f72C}',
+
+            VirtualKeyCode::Up => '\u{f700}',
+            VirtualKeyCode::Down => '\u{f701}',
+            VirtualKeyCode::Left => '\u{f702}',
+            VirtualKeyCode::Right => '\u{f703}',
+
+            VirtualKeyCode::Back => '\u{0008}',
+            VirtualKeyCode::Return => '\u{000d}',
+            VirtualKeyCode::Space => '\u{0020}',
+            VirtualKeyCode::Escape => '\u{001b}',
+            _ => ' ',
+        };
+
+        let mut mask = NSEventModifierFlags::empty();
+        if self.modifiers.logo(){
+            mask.set(NSEventModifierFlags::NSCommandKeyMask, true);
+        }
+        
+        if self.modifiers.ctrl(){
+            mask.set(NSEventModifierFlags::NSControlKeyMask, true);
+        }
+        
+        if self.modifiers.shift(){
+            mask.set(NSEventModifierFlags::NSShiftKeyMask, true);
+        }
+        
+        if self.modifiers.alt(){
+            mask.set(NSEventModifierFlags::NSAlternateKeyMask, true);
+        }
+
+        (String::from(key), Some(mask))
+    }
+}
+
 struct KeyEquivalent<'a> {
     key: &'a str,
     masks: Option<NSEventModifierFlags>,
 }
 
-pub fn initialize() {
-    autoreleasepool(|| unsafe {
-        let menubar = IdRef::new(NSMenu::new(nil));
-        let app_menu_item = IdRef::new(NSMenuItem::new(nil));
-        menubar.addItem_(*app_menu_item);
-        let app = NSApp();
-        app.setMainMenu_(*menubar);
+impl Default for Menu{
+    fn default() -> Self {
+        autoreleasepool(|| unsafe {
+            let menubar = IdRef::new(NSMenu::new(nil));
+            let app_menu_item = IdRef::new(NSMenuItem::new(nil));
+            menubar.addItem_(*app_menu_item);
 
-        let app_menu = NSMenu::new(nil);
-        let process_name = NSProcessInfo::processInfo(nil).processName();
+            let app_menu = NSMenu::new(nil);
+            let process_name = NSProcessInfo::processInfo(nil).processName();
 
-        // About menu item
-        let about_item_prefix = NSString::alloc(nil).init_str("About ");
-        let about_item_title = about_item_prefix.stringByAppendingString_(process_name);
-        let about_item = menu_item(
-            about_item_title,
-            selector("orderFrontStandardAboutPanel:"),
-            None,
-        );
+            // About menu item
+            let about_item_prefix = NSString::alloc(nil).init_str("About ");
+            let about_item_title = about_item_prefix.stringByAppendingString_(process_name);
+            let about_item = menu_item(
+                about_item_title,
+                selector("orderFrontStandardAboutPanel:"),
+                None,
+            );
 
-        // Seperator menu item
-        let sep_first = NSMenuItem::separatorItem(nil);
+            // Seperator menu item
+            let sep_first = NSMenuItem::separatorItem(nil);
 
-        // Hide application menu item
-        let hide_item_prefix = NSString::alloc(nil).init_str("Hide ");
-        let hide_item_title = hide_item_prefix.stringByAppendingString_(process_name);
-        let hide_item = menu_item(
-            hide_item_title,
-            selector("hide:"),
-            Some(KeyEquivalent {
-                key: "h",
-                masks: None,
-            }),
-        );
+            // Hide application menu item
+            let hide_item_prefix = NSString::alloc(nil).init_str("Hide ");
+            let hide_item_title = hide_item_prefix.stringByAppendingString_(process_name);
+            let hide_item = menu_item(
+                hide_item_title,
+                selector("hide:"),
+                Some(KeyEquivalent {
+                    key: "h",
+                    masks: None,
+                }),
+            );
 
-        // Hide other applications menu item
-        let hide_others_item_title = NSString::alloc(nil).init_str("Hide Others");
-        let hide_others_item = menu_item(
-            hide_others_item_title,
-            selector("hideOtherApplications:"),
-            Some(KeyEquivalent {
-                key: "h",
-                masks: Some(
-                    NSEventModifierFlags::NSAlternateKeyMask
-                        | NSEventModifierFlags::NSCommandKeyMask,
-                ),
-            }),
-        );
+            // Hide other applications menu item
+            let hide_others_item_title = NSString::alloc(nil).init_str("Hide Others");
+            let hide_others_item = menu_item(
+                hide_others_item_title,
+                selector("hideOtherApplications:"),
+                Some(KeyEquivalent {
+                    key: "h",
+                    masks: Some(
+                        NSEventModifierFlags::NSAlternateKeyMask
+                            | NSEventModifierFlags::NSCommandKeyMask,
+                    ),
+                }),
+            );
 
-        // Show applications menu item
-        let show_all_item_title = NSString::alloc(nil).init_str("Show All");
-        let show_all_item = menu_item(
-            show_all_item_title,
-            selector("unhideAllApplications:"),
-            None,
-        );
+            // Show applications menu item
+            let show_all_item_title = NSString::alloc(nil).init_str("Show All");
+            let show_all_item = menu_item(
+                show_all_item_title,
+                selector("unhideAllApplications:"),
+                None,
+            );
 
-        // Seperator menu item
-        let sep = NSMenuItem::separatorItem(nil);
+            // Seperator menu item
+            let sep = NSMenuItem::separatorItem(nil);
 
-        // Quit application menu item
-        let quit_item_prefix = NSString::alloc(nil).init_str("Quit ");
-        let quit_item_title = quit_item_prefix.stringByAppendingString_(process_name);
-        let quit_item = menu_item(
-            quit_item_title,
-            selector("terminate:"),
-            Some(KeyEquivalent {
-                key: "q",
-                masks: None,
-            }),
-        );
+            // Quit application menu item
+            let quit_item_prefix = NSString::alloc(nil).init_str("Quit ");
+            let quit_item_title = quit_item_prefix.stringByAppendingString_(process_name);
+            let quit_item = menu_item(
+                quit_item_title,
+                selector("terminate:"),
+                Some(KeyEquivalent {
+                    key: "q",
+                    masks: None,
+                }),
+            );
 
-        app_menu.addItem_(about_item);
-        app_menu.addItem_(sep_first);
-        app_menu.addItem_(hide_item);
-        app_menu.addItem_(hide_others_item);
-        app_menu.addItem_(show_all_item);
-        app_menu.addItem_(sep);
-        app_menu.addItem_(quit_item);
-        app_menu_item.setSubmenu_(app_menu);
-    });
+            app_menu.addItem_(about_item);
+            app_menu.addItem_(sep_first);
+            app_menu.addItem_(hide_item);
+            app_menu.addItem_(hide_others_item);
+            app_menu.addItem_(show_all_item);
+            app_menu.addItem_(sep);
+            app_menu.addItem_(quit_item);
+            app_menu_item.setSubmenu_(app_menu);
+
+            Menu{
+                raw: menubar,
+            }
+        })
+    }
 }
 
 fn menu_item(
@@ -111,5 +240,57 @@ fn menu_item(
         }
 
         item
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Menu {
+    pub (crate) raw: IdRef,
+}
+
+impl Menu {
+    pub fn new() -> Self {
+        unsafe{
+            Self{
+                raw: IdRef::new(NSMenu::new(nil)),
+            }
+        }
+    }
+
+    pub fn add_item<S: Into<String>, H: Into<Option<Hotkey>>>(&mut self, id: usize, name: S, key: H) {
+        autoreleasepool(||unsafe{
+            let title = NSString::alloc(nil).init_str(&name.into());
+            let (key, mask) = match key.into(){
+                Some(hotkey) => hotkey.parse(),
+                None => (String::new(), None),
+            };
+
+            let key = NSString::alloc(nil).init_str(&key);
+            let menu_item = NSMenuItem::alloc(nil).initWithTitle_action_keyEquivalent_(title, selector("handle_menu:"), key);
+            let () = msg_send![menu_item, setTag: id as isize];
+            if let Some(mask) = mask{
+                menu_item.setKeyEquivalentModifierMask_(mask);
+            }
+
+            self.raw.addItem_(menu_item);
+        });
+    }
+
+    pub fn add_dropdown<S: Into<String>>(&mut self, name: S, menu: Menu) {
+        autoreleasepool(||unsafe{
+            let title = NSString::alloc(nil).init_str(&name.into());
+            let menu_item = NSMenuItem::alloc(nil);
+            let () = msg_send![*menu.raw, setTitle: title];
+            menu_item.setSubmenu_(*menu.raw);
+
+            self.raw.addItem_(menu_item);
+        });
+    }
+
+    pub fn add_separator(&mut self) {
+        autoreleasepool(||unsafe{
+            let menu_item = NSMenuItem::separatorItem(nil);
+            self.raw.addItem_(menu_item);
+        });
     }
 }

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -1,5 +1,5 @@
-use crate::event::{ModifiersState, VirtualKeyCode};
 use super::util::IdRef;
+use crate::event::{ModifiersState, VirtualKeyCode};
 use cocoa::appkit::{NSEventModifierFlags, NSMenu, NSMenuItem};
 use cocoa::base::{nil, selector};
 use cocoa::foundation::{NSProcessInfo, NSString};
@@ -8,21 +8,18 @@ use objc::{
     runtime::{Object, Sel},
 };
 
-pub struct Hotkey{
+pub struct Hotkey {
     modifiers: ModifiersState,
-    key: VirtualKeyCode
+    key: VirtualKeyCode,
 }
 
-impl Hotkey{
-    pub fn new(modifiers: ModifiersState, key: VirtualKeyCode) -> Self{
-        Self{
-            modifiers,
-            key,
-        }
+impl Hotkey {
+    pub fn new(modifiers: ModifiersState, key: VirtualKeyCode) -> Self {
+        Self { modifiers, key }
     }
 
-    fn parse(&self) -> (String, Option<NSEventModifierFlags>){
-        let key = match self.key{
+    fn parse(&self) -> (String, Option<NSEventModifierFlags>) {
+        let key = match self.key {
             VirtualKeyCode::Key1 => '1',
             VirtualKeyCode::Key2 => '2',
             VirtualKeyCode::Key3 => '3',
@@ -112,19 +109,19 @@ impl Hotkey{
         };
 
         let mut mask = NSEventModifierFlags::empty();
-        if self.modifiers.logo(){
+        if self.modifiers.logo() {
             mask.set(NSEventModifierFlags::NSCommandKeyMask, true);
         }
-        
-        if self.modifiers.ctrl(){
+
+        if self.modifiers.ctrl() {
             mask.set(NSEventModifierFlags::NSControlKeyMask, true);
         }
-        
-        if self.modifiers.shift(){
+
+        if self.modifiers.shift() {
             mask.set(NSEventModifierFlags::NSShiftKeyMask, true);
         }
-        
-        if self.modifiers.alt(){
+
+        if self.modifiers.alt() {
             mask.set(NSEventModifierFlags::NSAlternateKeyMask, true);
         }
 
@@ -137,7 +134,7 @@ struct KeyEquivalent<'a> {
     masks: Option<NSEventModifierFlags>,
 }
 
-impl Default for Menu{
+impl Default for Menu {
     fn default() -> Self {
         autoreleasepool(|| unsafe {
             let menubar = IdRef::new(NSMenu::new(nil));
@@ -217,9 +214,7 @@ impl Default for Menu{
             app_menu.addItem_(quit_item);
             app_menu_item.setSubmenu_(app_menu);
 
-            Menu{
-                raw: menubar,
-            }
+            Menu { raw: menubar }
         })
     }
 }
@@ -245,30 +240,39 @@ fn menu_item(
 
 #[derive(Debug, Clone)]
 pub struct Menu {
-    pub (crate) raw: IdRef,
+    pub(crate) raw: IdRef,
 }
 
 impl Menu {
     pub fn new() -> Self {
-        unsafe{
-            Self{
+        unsafe {
+            Self {
                 raw: IdRef::new(NSMenu::new(nil)),
             }
         }
     }
 
-    pub fn add_item<S: Into<String>, H: Into<Option<Hotkey>>>(&mut self, id: usize, name: S, key: H) {
-        autoreleasepool(||unsafe{
+    pub fn add_item<S: Into<String>, H: Into<Option<Hotkey>>>(
+        &mut self,
+        id: usize,
+        name: S,
+        key: H,
+    ) {
+        autoreleasepool(|| unsafe {
             let title = NSString::alloc(nil).init_str(&name.into());
-            let (key, mask) = match key.into(){
+            let (key, mask) = match key.into() {
                 Some(hotkey) => hotkey.parse(),
                 None => (String::new(), None),
             };
 
             let key = NSString::alloc(nil).init_str(&key);
-            let menu_item = NSMenuItem::alloc(nil).initWithTitle_action_keyEquivalent_(title, selector("handle_menu:"), key);
+            let menu_item = NSMenuItem::alloc(nil).initWithTitle_action_keyEquivalent_(
+                title,
+                selector("handle_menu:"),
+                key,
+            );
             let () = msg_send![menu_item, setTag: id as isize];
-            if let Some(mask) = mask{
+            if let Some(mask) = mask {
                 menu_item.setKeyEquivalentModifierMask_(mask);
             }
 
@@ -277,7 +281,7 @@ impl Menu {
     }
 
     pub fn add_dropdown<S: Into<String>>(&mut self, name: S, menu: Menu) {
-        autoreleasepool(||unsafe{
+        autoreleasepool(|| unsafe {
             let title = NSString::alloc(nil).init_str(&name.into());
             let menu_item = NSMenuItem::alloc(nil);
             let () = msg_send![*menu.raw, setTitle: title];
@@ -288,7 +292,7 @@ impl Menu {
     }
 
     pub fn add_separator(&mut self) {
-        autoreleasepool(||unsafe{
+        autoreleasepool(|| unsafe {
             let menu_item = NSMenuItem::separatorItem(nil);
             self.raw.addItem_(menu_item);
         });

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -19,7 +19,7 @@ use std::{fmt, ops::Deref, sync::Arc};
 pub use self::{
     app_delegate::{get_aux_state_mut, AuxDelegateState},
     event_loop::{EventLoop, EventLoopWindowTarget, Proxy as EventLoopProxy},
-    menu::{Menu, Hotkey},
+    menu::{Hotkey, Menu},
     monitor::{MonitorHandle, VideoMode},
     window::{Id as WindowId, PlatformSpecificWindowBuilderAttributes, UnownedWindow},
 };

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -19,6 +19,7 @@ use std::{fmt, ops::Deref, sync::Arc};
 pub use self::{
     app_delegate::{get_aux_state_mut, AuxDelegateState},
     event_loop::{EventLoop, EventLoopWindowTarget, Proxy as EventLoopProxy},
+    menu::{Menu, Hotkey},
     monitor::{MonitorHandle, VideoMode},
     window::{Id as WindowId, PlatformSpecificWindowBuilderAttributes, UnownedWindow},
 };

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -29,7 +29,7 @@ use crate::{
         OsError,
     },
     window::{
-        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId, Menu,
+        CursorIcon, Fullscreen, Menu, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
     },
 };
 use cocoa::{
@@ -890,7 +890,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_menu(&self, menu: Option<Menu>) {
-        unsafe{
+        unsafe {
             let ns_app = NSApplication::sharedApplication(nil);
             if let Some(ref menu) = menu {
                 ns_app.setMainMenu_(*menu.raw);

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -29,7 +29,7 @@ use crate::{
         OsError,
     },
     window::{
-        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
+        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId, Menu,
     },
 };
 use cocoa::{
@@ -382,6 +382,7 @@ impl UnownedWindow {
         // `WindowDelegate` to update the state.
         let fullscreen = win_attribs.fullscreen.take();
         let maximized = win_attribs.maximized;
+        let menu = win_attribs.menu.take();
         let visible = win_attribs.visible;
         let decorations = win_attribs.decorations;
         let inner_rect = win_attribs
@@ -402,6 +403,8 @@ impl UnownedWindow {
 
         // Set fullscreen mode after we setup everything
         window.set_fullscreen(fullscreen);
+
+        window.set_menu(menu);
 
         // Setting the window as key has to happen *after* we set the fullscreen
         // state, since otherwise we'll briefly see the window at normal size
@@ -882,6 +885,18 @@ impl UnownedWindow {
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
             },
             _ => INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst),
+        }
+    }
+
+    #[inline]
+    pub fn set_menu(&self, menu: Option<Menu>) {
+        unsafe{
+            let ns_app = NSApplication::sharedApplication(nil);
+            if let Some(ref menu) = menu {
+                ns_app.setMainMenu_(*menu.raw);
+            } else {
+                ns_app.setMainMenu_(nil);
+            }
         }
     }
 

--- a/src/platform_impl/web/menu.rs
+++ b/src/platform_impl/web/menu.rs
@@ -1,0 +1,62 @@
+use crate::event::{ModifiersState, VirtualKeyCode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Hotkey {
+    modifiers: ModifiersState,
+    key: VirtualKeyCode,
+}
+
+impl Hotkey {
+    pub fn new(modifiers: ModifiersState, key: VirtualKeyCode) -> Self {
+        Self { modifiers, key }
+    }
+}
+
+impl From<Hotkey> for String {
+    fn from(hotkey: Hotkey) -> Self {
+        let mut string = String::new();
+        if hotkey.modifiers.logo() {
+            string.push_str("Super+");
+        }
+        if hotkey.modifiers.ctrl() {
+            string.push_str("Ctrl+");
+        }
+        if hotkey.modifiers.shift() {
+            string.push_str("Shift+");
+        }
+        if hotkey.modifiers.alt() {
+            string.push_str("Alt+");
+        }
+
+        string.push_str(&String::from(hotkey.key));
+
+        string
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Menu;
+
+impl Menu {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn add_item<S: Into<String>, H: Into<Option<Hotkey>>>(
+        &mut self,
+        _id: usize,
+        _name: S,
+        _key: H,
+    ) {
+    }
+
+    pub fn add_dropdown<S: Into<String>>(&mut self, _name: S, _menu: Menu) {}
+
+    pub fn add_separator(&mut self) {}
+}
+
+impl Default for Menu {
+    fn default() -> Self {
+        Menu::new()
+    }
+}

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -20,6 +20,7 @@
 mod device;
 mod error;
 mod event_loop;
+mod menu;
 mod monitor;
 mod window;
 
@@ -31,6 +32,7 @@ pub use self::error::OsError;
 pub use self::event_loop::{
     EventLoop, Proxy as EventLoopProxy, WindowTarget as EventLoopWindowTarget,
 };
+pub use self::menu::{Hotkey, Menu};
 pub use self::monitor::{Handle as MonitorHandle, Mode as VideoMode};
 pub use self::window::{
     Id as WindowId, PlatformSpecificBuilderAttributes as PlatformSpecificWindowBuilderAttributes,

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -9,7 +9,7 @@ use crate::window::{
 
 use raw_window_handle::web::WebHandle;
 
-use super::{backend, monitor, EventLoopWindowTarget};
+use super::{backend, monitor, EventLoopWindowTarget, Menu};
 
 use std::cell::{Ref, RefCell};
 use std::collections::vec_deque::IntoIter as VecDequeIter;
@@ -88,6 +88,9 @@ impl Window {
     pub fn set_visible(&self, _visible: bool) {
         // Intentionally a no-op
     }
+
+    #[inline]
+    pub fn set_menu(&self, _menu: Option<Menu>) {}
 
     pub fn request_redraw(&self) {
         (self.register_redraw_request)();

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -859,6 +859,17 @@ unsafe fn public_window_callback_inner<T: 'static>(
             0
         }
 
+        winuser::WM_COMMAND => {
+            use crate::event::WindowEvent::MenuEntryActivated;
+            let id = LOWORD(wparam as DWORD) as isize;
+
+            subclass_input.send_event(Event::WindowEvent {
+                window_id: RootWindowId(WindowId(window)),
+                event: MenuEntryActivated(id),
+            });
+            0
+        }
+
         winuser::WM_DESTROY => {
             use crate::event::WindowEvent::Destroyed;
             ole2::RevokeDragDrop(window);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -861,7 +861,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
         winuser::WM_COMMAND => {
             use crate::event::WindowEvent::MenuEntryActivated;
-            let id = LOWORD(wparam as DWORD) as isize;
+            let id = LOWORD(wparam as DWORD) as u32;
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -6,6 +6,7 @@ use winapi::shared::basetsd::UINT_PTR;
 use winapi::shared::windef::HMENU__;
 use winapi::um::winuser;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Hotkey {
     modifiers: ModifiersState,
     key: VirtualKeyCode,

--- a/src/platform_impl/windows/menu.rs
+++ b/src/platform_impl/windows/menu.rs
@@ -1,0 +1,98 @@
+use crate::{event::{ModifiersState, VirtualKeyCode}, platform_impl::platform::util};
+use winapi::shared::windef::HMENU__;
+use winapi::shared::basetsd::UINT_PTR;
+use winapi::um::winuser;
+
+pub struct Hotkey{
+    modifiers: ModifiersState,
+    key: VirtualKeyCode
+}
+
+impl Hotkey{
+    pub fn new(modifiers: ModifiersState, key: VirtualKeyCode) -> Self{
+        Self{
+            modifiers,
+            key,
+        }
+    }
+}
+
+impl From<Hotkey> for String{
+    fn from(hotkey: Hotkey) -> Self {
+        let mut string = String::new();
+        if hotkey.modifiers.logo(){
+            #[cfg(windows)]
+            string.push_str("Windows+");
+            #[cfg(linux)]
+            string.push_str("Super+");
+            #[cfg(macos)]
+            string.push_str("Command+");
+        }
+
+        if hotkey.modifiers.ctrl(){
+            string.push_str("Ctrl+");
+        }
+
+        if hotkey.modifiers.shift(){
+            string.push_str("Shift+");
+        }
+
+        if hotkey.modifiers.alt(){
+            #[cfg(not(macos))]
+            string.push_str("Alt+");
+            #[cfg(macos)]
+            string.push_str("Option+");
+        }
+
+        string.push_str(&String::from(hotkey.key));
+
+        string
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Menu {
+    pub(crate) raw: *mut HMENU__,
+}
+
+impl Menu {
+    pub fn new() -> Self {
+        unsafe{
+            Self{
+                raw: winuser::CreateMenu(),
+            }
+        }
+    }
+
+    pub fn add_item<S: Into<String>, H: Into<Option<Hotkey>>>(&mut self, id: usize, name: S, key: H) {
+        let content = if let Some(key) = key.into(){
+            format!("{}\t{}", name.into(), String::from(key))
+        }else{
+            format!("{}", name.into())
+        };
+
+        unsafe{
+            winuser::AppendMenuW(self.raw, winuser::MF_STRING, id as UINT_PTR, util::string_to_wchar(&content).as_mut_ptr());
+        }
+    }
+
+    pub fn add_dropdown<S: Into<String>>(&mut self, name: S, menu: Menu) {
+        unsafe{
+            winuser::AppendMenuW(self.raw, winuser::MF_POPUP, menu.raw as UINT_PTR, util::string_to_wchar(&name.into()).as_mut_ptr());
+        }
+    }
+
+    pub fn add_separator(&mut self) {
+        unsafe{
+            winuser::AppendMenuW(self.raw, winuser::MF_SEPARATOR, 0, std::ptr::null());
+        }
+    }
+}
+
+impl Drop for Menu{
+    fn drop(&mut self) {
+        unsafe{
+            winuser::DestroyMenu(self.raw);
+        }
+    }
+}

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -7,6 +7,7 @@ pub use self::{
     icon::WinIcon,
     monitor::{MonitorHandle, VideoMode},
     window::Window,
+    menu::{Menu, Hotkey},
 };
 
 pub use self::icon::WinIcon as PlatformIcon;
@@ -103,6 +104,7 @@ mod drop_handler;
 mod event;
 mod event_loop;
 mod icon;
+mod menu;
 mod monitor;
 mod raw_input;
 mod window;

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -5,9 +5,9 @@ use winapi::{self, shared::windef::HMENU, shared::windef::HWND};
 pub use self::{
     event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget},
     icon::WinIcon,
+    menu::{Hotkey, Menu},
     monitor::{MonitorHandle, VideoMode},
     window::Window,
-    menu::{Menu, Hotkey},
 };
 
 pub use self::icon::WinIcon as PlatformIcon;

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -2,6 +2,7 @@ use std::{
     io, mem,
     ops::BitAnd,
     os::raw::c_void,
+    os::windows::ffi::OsStrExt,
     ptr, slice,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -27,6 +28,13 @@ where
     T: Copy + PartialEq + BitAnd<T, Output = T>,
 {
     bitset & flag == flag
+}
+
+pub fn string_to_wchar(string: &str) -> Vec<wchar_t>{
+    std::ffi::OsStr::new(string)
+        .encode_wide()
+        .chain(Some(0))
+        .collect()
 }
 
 pub fn wchar_to_string(wchar: &[wchar_t]) -> String {

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -30,7 +30,7 @@ where
     bitset & flag == flag
 }
 
-pub fn string_to_wchar(string: &str) -> Vec<wchar_t>{
+pub fn string_to_wchar(string: &str) -> Vec<wchar_t> {
     std::ffi::OsStr::new(string)
         .encode_wide()
         .chain(Some(0))

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -46,7 +46,7 @@ use crate::{
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
         Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
-    window::{CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes, Menu},
+    window::{CursorIcon, Fullscreen, Menu, Theme, UserAttentionType, WindowAttributes},
 };
 
 /// The Win32 implementation of the main `Window` object.
@@ -619,15 +619,14 @@ impl Window {
 
     #[inline]
     pub fn set_menu(&self, menu: Option<Menu>) {
-        unsafe{
+        unsafe {
             if let Some(ref menu) = menu {
-                    winuser::SetMenu(self.window.0, menu.raw);
+                winuser::SetMenu(self.window.0, menu.raw);
             } else {
-                    winuser::SetMenu(self.window.0, std::ptr::null_mut());
+                winuser::SetMenu(self.window.0, std::ptr::null_mut());
             }
         }
     }
-    
 
     #[inline]
     pub fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -46,7 +46,7 @@ use crate::{
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
         Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
-    window::{CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes},
+    window::{CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes, Menu},
 };
 
 /// The Win32 implementation of the main `Window` object.
@@ -618,6 +618,18 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_menu(&self, menu: Option<Menu>) {
+        unsafe{
+            if let Some(ref menu) = menu {
+                    winuser::SetMenu(self.window.0, menu.raw);
+            } else {
+                    winuser::SetMenu(self.window.0, std::ptr::null_mut());
+            }
+        }
+    }
+    
+
+    #[inline]
     pub fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {
         if let Some(ref taskbar_icon) = taskbar_icon {
             taskbar_icon
@@ -779,7 +791,7 @@ unsafe fn init<T: 'static>(
             winuser::CW_USEDEFAULT,
             winuser::CW_USEDEFAULT,
             parent.unwrap_or(ptr::null_mut()),
-            pl_attribs.menu.unwrap_or(ptr::null_mut()),
+            attributes.menu.as_ref().map_or(ptr::null_mut(), |m| m.raw),
             libloaderapi::GetModuleHandleW(ptr::null()),
             ptr::null_mut(),
         );

--- a/src/window.rs
+++ b/src/window.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 pub use crate::icon::{BadIcon, Icon};
-pub use crate::platform_impl::{Menu, Hotkey};
+pub use crate::platform_impl::{Hotkey, Menu};
 
 /// Represents a window.
 ///
@@ -372,7 +372,6 @@ impl WindowBuilder {
         self.window.menu = menu;
         self
     }
-    
 
     /// Builds the window.
     ///

--- a/src/window.rs
+++ b/src/window.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 
 pub use crate::icon::{BadIcon, Icon};
+pub use crate::platform_impl::{Menu, Hotkey};
 
 /// Represents a window.
 ///
@@ -186,6 +187,11 @@ pub struct WindowAttributes {
     ///
     /// The default is `None`.
     pub window_icon: Option<Icon>,
+
+    /// The window menu.
+    ///
+    /// The default is `None`.
+    pub menu: Option<Menu>,
 }
 
 impl Default for WindowAttributes {
@@ -205,6 +211,7 @@ impl Default for WindowAttributes {
             decorations: true,
             always_on_top: false,
             window_icon: None,
+            menu: None,
         }
     }
 }
@@ -354,6 +361,18 @@ impl WindowBuilder {
         self.window.window_icon = window_icon;
         self
     }
+
+    /// Sets the window menu.
+    ///
+    /// See [`Window::set_menu`] for details.
+    ///
+    /// [`Window::set_menu`]: crate::window::Window::set_menu
+    #[inline]
+    pub fn with_menu(mut self, menu: Option<Menu>) -> Self {
+        self.window.menu = menu;
+        self
+    }
+    
 
     /// Builds the window.
     ///
@@ -719,6 +738,18 @@ impl Window {
     #[inline]
     pub fn set_window_icon(&self, window_icon: Option<Icon>) {
         self.window.set_window_icon(window_icon)
+    }
+
+    /// Sets the window menu.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / Linux:** Unsupported.
+    ///
+    /// This is only supported on Windows and macOS.
+    #[inline]
+    pub fn set_menu(&self, menu: Option<Menu>) {
+        self.window.set_menu(menu)
     }
 
     /// Sets location of IME candidate box in client area coordinates relative to the top left.


### PR DESCRIPTION
This PR introduces native menus, currently only implemented for Windows & MacOS, it also creates a new `Hotkey` struct that aims to unify key combinations for the implemented platforms.

Note: Currently this won't work on anything outside of the implemented platform. I'm not sure how the API should work in this case.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
