### PR TITLE
On X11, don't panic when getting EINTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 - On Wayland, bump `smithay-client-toolkit` to 0.15.
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
+- On X11, if RANDR based scale factor is higher than 20 reset it to 1
+- On Wayland, add an enabled-by-default feature called `wayland-dlopen` so users can opt out of using `dlopen` to load system libraries.
+- **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.4.
+- On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
+- On macOS, fix native file dialogs hanging the event loop.
+- On Wayland, implement a workaround for wrong configure size when using `xdg_decoration` in `kwin_wayland`
+- On macOS, fix an issue that prevented the menu bar from showing in borderless fullscreen mode.
+- On X11, EINTR while polling for events no longer causes a panic. Instead it will be treated as a spurious wakeup.
 
 # 0.25.0 (2021-05-15)
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -360,7 +360,11 @@ impl<T: 'static> EventLoop<T> {
             // If the XConnection already contains buffered events, we don't
             // need to wait for data on the socket.
             if !self.event_processor.poll() {
-                self.poll.poll(&mut events, timeout).unwrap();
+                if let Err(e) = self.poll.poll(&mut events, timeout) {
+                    if e.raw_os_error() != Some(libc::EINTR) {
+                        panic!("epoll returned an error: {:?}", e);
+                    }
+                }
                 events.clear();
             }
 


### PR DESCRIPTION
Cherry-picks e9d5b2007a5b7cb70a514dad6812fbc22f2f619c from https://github.com/rust-windowing/winit/pull/2031 which fixes #1972.

`winit` panics on Linux when debugging from this `EINTR`, and appears to also happen when entering / resuming from sleep.