### PR TITLE
Update to winit 0.28.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ['1.60.0', stable, nightly]
+        rust_version: [stable, nightly]
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [1.57.0, stable, nightly]
+        rust_version: [stable, nightly]
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
@@ -99,7 +99,7 @@ jobs:
 
     - name: Lint with clippy
       shell: bash
-      if: (matrix.rust_version == '1.57.0') && !contains(matrix.platform.options, '--no-default-features')
+      if: (matrix.rust_version == 'stable') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
 
     - name: Build tests with serde enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Wayland, fix crash when dropping a window in multi-window setup.
+
 # 0.28.0
 
 - On macOS, fixed `Ime::Commit` persisting for all input after interacting with `Ime`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Implement `HasRawDisplayHandle` for `EventLoop`.
 - On macOS, set resize increments only for live resizes.
 - On Wayland, fix rare crash on DPI change
+- Web: Added support for `Window::theme`.
 
 # 0.28.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+# 0.28.0
+
 - On macOS, fixed `Ime::Commit` persisting for all input after interacting with `Ime`.
 - On macOS, added `WindowExtMacOS::option_as_alt` and `WindowExtMacOS::set_option_as_alt`.
 - On Windows, fix window size for maximized, undecorated windows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix rare crash on DPI change
 - Web: Added support for `Window::theme`.
 - On Wayland, fix rounding issues when doing resize.
+- On macOS, fix wrong focused state on startup.
 
 # 0.28.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Implement `HasRawDisplayHandle` for `EventLoop`.
+
 # 0.28.1
 
 - On Wayland, fix crash when dropping a window in multi-window setup.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - Implement `HasRawDisplayHandle` for `EventLoop`.
+- On macOS, set resize increments only for live resizes.
 
 # 0.28.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+# 0.28.1
+
 - On Wayland, fix crash when dropping a window in multi-window setup.
 
 # 0.28.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On macOS, set resize increments only for live resizes.
 - On Wayland, fix rare crash on DPI change
 - Web: Added support for `Window::theme`.
+- On Wayland, fix rounding issues when doing resize.
 
 # 0.28.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Implement `HasRawDisplayHandle` for `EventLoop`.
 - On macOS, set resize increments only for live resizes.
+- On Wayland, fix rare crash on DPI change
 
 # 0.28.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.27.5"
+version = "0.28.0"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.28.0"
+version = "0.28.1"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 edition = "2021"

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -179,7 +179,7 @@ Legend:
 |Providing pointer to init Vulkan |✔️     |✔️     |✔️         |✔️             |✔️     |❓     |**N/A**|**N/A** |
 |Window decorations               |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|✔️      |
 |Window decorations toggle        |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|**N/A** |
-|Window resizing                  |✔️     |▢[#219]|✔️         |▢[#306]        |**N/A**|**N/A**|✔️        |✔️      |
+|Window resizing                  |✔️     |✔️     |✔️         |✔️        |**N/A**|**N/A**|✔️        |✔️      |
 |Window resize increments         |❌     |✔️     |✔️         |❌             |**N/A**|**N/A**|**N/A**|**N/A** |
 |Window transparency              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|N/A        |✔️      |
 |Window maximization              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|**N/A** |
@@ -210,7 +210,7 @@ Legend:
 |Touch pressure          |✔️       |❌      |❌       |❌          |❌    |✔️     |✔️        |**N/A** |
 |Multitouch              |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |**N/A** |
 |Keyboard events         |✔️       |✔️      |✔️       |✔️          |✔️    |❌     |✔️        |✔️      |
-|Drag & Drop             |▢[#720]  |▢[#720] |▢[#720]  |❌[#306]    |**N/A**|**N/A**|❓        |**N/A** |
+|Drag & Drop             |▢[#720]  |▢[#720] |▢[#720]  |▢[#720]   |**N/A**|**N/A**|❓        |**N/A** |
 |Raw Device Events       |▢[#750]  |▢[#750] |▢[#750]  |❌          |❌    |❌     |❓        |**N/A** |
 |Gamepad/Joystick events |❌[#804] |❌      |❌       |❌          |❌    |❌     |❓        |**N/A** |
 |Device movement events  |❓        |❓       |❓       |❓           |❌    |❌     |❓        |**N/A** |
@@ -223,7 +223,7 @@ Changes in the API that have been agreed upon but aren't implemented across all 
 |Feature                             |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |WASM      |Redox OS|
 |------------------------------      | ----- | ---- | ------- | ----------- | ----- | ----- | -------- | ------ |
 |New API for HiDPI ([#315] [#319])   |✔️    |✔️    |✔️       |✔️          |✔️     |✔️    |❓        |❓      |
-|Event Loop 2.0 ([#459])             |✔️    |✔️    |❌       |✔️          |✔️     |✔️    |❓        |❓      |
+|Event Loop 2.0 ([#459])             |✔️    |✔️    |✔️       |✔️          |✔️     |✔️    |❓        |❓      |
 |Keyboard Input ([#812])             |❌    |❌    |❌       |❌          |❌     |❌    |❓        |❓      |
 
 ### Completed API Reworks

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-winit = "0.27.5"
+winit = "0.28.0"
 ```
 
 ## [Documentation](https://docs.rs/winit)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-winit = "0.28.0"
+winit = "0.28.1"
 ```
 
 ## [Documentation](https://docs.rs/winit)

--- a/src/event.rs
+++ b/src/event.rs
@@ -229,6 +229,21 @@ pub enum Event<'a, T: 'static> {
     /// This is irreversible - if this event is emitted, it is guaranteed to be the last event that
     /// gets emitted. You generally want to treat this as an "do on quit" event.
     LoopDestroyed,
+
+    /// Emitted when the event loop receives an event that only occurs on some specific platform.
+    PlatformSpecific(PlatformSpecific),
+}
+
+/// Describes an event from some specific platform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlatformSpecific {
+    MacOS(MacOS),
+}
+
+/// Describes an event that only happens in `MacOS`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacOS {
+    ReceivedUrl(String),
 }
 
 impl<T: Clone> Clone for Event<'static, T> {
@@ -251,6 +266,7 @@ impl<T: Clone> Clone for Event<'static, T> {
             LoopDestroyed => LoopDestroyed,
             Suspended => Suspended,
             Resumed => Resumed,
+            PlatformSpecific(event) => PlatformSpecific(event.clone()),
         }
     }
 }
@@ -269,6 +285,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Ok(LoopDestroyed),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
+            PlatformSpecific(event) => Ok(PlatformSpecific(event)),
         }
     }
 
@@ -289,6 +306,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Some(LoopDestroyed),
             Suspended => Some(Suspended),
             Resumed => Some(Resumed),
+            PlatformSpecific(event) => Some(PlatformSpecific(event)),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -220,6 +220,8 @@ pub enum Event<'a, T: 'static> {
     /// This is irreversible - if this event is emitted, it is guaranteed to be the last event that
     /// gets emitted. You generally want to treat this as an "do on quit" event.
     LoopDestroyed,
+
+    ReceivedUrl(String),
 }
 
 impl<T: Clone> Clone for Event<'static, T> {
@@ -242,6 +244,7 @@ impl<T: Clone> Clone for Event<'static, T> {
             LoopDestroyed => LoopDestroyed,
             Suspended => Suspended,
             Resumed => Resumed,
+            ReceivedUrl(url) => ReceivedUrl(url.clone()),
         }
     }
 }
@@ -260,6 +263,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Ok(LoopDestroyed),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
+            ReceivedUrl(url) => Ok(ReceivedUrl(url)),
         }
     }
 
@@ -280,6 +284,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Some(LoopDestroyed),
             Suspended => Some(Suspended),
             Resumed => Some(Resumed),
+            ReceivedUrl(url) => Some(ReceivedUrl(url)),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -221,6 +221,19 @@ pub enum Event<'a, T: 'static> {
     /// gets emitted. You generally want to treat this as an "do on quit" event.
     LoopDestroyed,
 
+    /// Emitted when the event loop receives an event that only occurs on some specific platform.
+    PlatformSpecific(PlatformSpecific),
+}
+
+/// Describes an event from some specific platform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlatformSpecific {
+    MacOS(MacOS),
+}
+
+/// Describes an event that only happens in `MacOS`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacOS {
     ReceivedUrl(String),
 }
 
@@ -244,7 +257,7 @@ impl<T: Clone> Clone for Event<'static, T> {
             LoopDestroyed => LoopDestroyed,
             Suspended => Suspended,
             Resumed => Resumed,
-            ReceivedUrl(url) => ReceivedUrl(url.clone()),
+            PlatformSpecific(event) => PlatformSpecific(event.clone()),
         }
     }
 }
@@ -263,7 +276,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Ok(LoopDestroyed),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
-            ReceivedUrl(url) => Ok(ReceivedUrl(url)),
+            PlatformSpecific(event) => Ok(PlatformSpecific(event)),
         }
     }
 
@@ -284,7 +297,7 @@ impl<'a, T> Event<'a, T> {
             LoopDestroyed => Some(LoopDestroyed),
             Suspended => Some(Suspended),
             Resumed => Some(Resumed),
-            ReceivedUrl(url) => Some(ReceivedUrl(url)),
+            PlatformSpecific(event) => Some(PlatformSpecific(event)),
         }
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -313,6 +313,13 @@ impl<T> EventLoop<T> {
     }
 }
 
+unsafe impl<T> HasRawDisplayHandle for EventLoop<T> {
+    /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
+    fn raw_display_handle(&self) -> RawDisplayHandle {
+        self.event_loop.window_target().p.raw_display_handle()
+    }
+}
+
 impl<T> Deref for EventLoop<T> {
     type Target = EventLoopWindowTarget<T>;
     fn deref(&self) -> &EventLoopWindowTarget<T> {

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -331,6 +331,7 @@ impl<T> EventLoopWindowTarget<T> {
     /// Returns the list of all the monitors available on the system.
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
+        #[allow(clippy::useless_conversion)]
         self.p
             .available_monitors()
             .into_iter()

--- a/src/platform_impl/linux/wayland/seat/keyboard/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/keyboard/handlers.rs
@@ -24,7 +24,10 @@ pub(super) fn handle_keyboard(
         KeyboardEvent::Enter { surface, .. } => {
             let window_id = wayland::make_wid(&surface);
 
-            let window_handle = winit_state.window_map.get_mut(&window_id).unwrap();
+            let window_handle = match winit_state.window_map.get_mut(&window_id) {
+                Some(window_handle) => window_handle,
+                None => return,
+            };
             window_handle.has_focus.store(true, Ordering::Relaxed);
 
             // Window gained focus.
@@ -39,7 +42,14 @@ pub(super) fn handle_keyboard(
             inner.target_window_id = Some(window_id);
         }
         KeyboardEvent::Leave { surface, .. } => {
+            // Reset the id.
+            inner.target_window_id = None;
+
             let window_id = wayland::make_wid(&surface);
+            let window_handle = match winit_state.window_map.get_mut(&window_id) {
+                Some(window_handle) => window_handle,
+                None => return,
+            };
 
             // Notify that no modifiers are being pressed.
             if !inner.modifiers_state.borrow().is_empty() {
@@ -49,14 +59,10 @@ pub(super) fn handle_keyboard(
                 );
             }
 
-            let window_handle = winit_state.window_map.get_mut(&window_id).unwrap();
             window_handle.has_focus.store(false, Ordering::Relaxed);
 
             // Window lost focus.
             event_sink.push_window_event(WindowEvent::Focused(false), window_id);
-
-            // Reset the id.
-            inner.target_window_id = None;
         }
         KeyboardEvent::Key {
             rawkey,

--- a/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
@@ -45,9 +45,6 @@ pub(super) fn handle_pointer(
             pointer_data.latest_enter_serial.replace(serial);
 
             let window_id = wayland::make_wid(&surface);
-            if !winit_state.window_map.contains_key(&window_id) {
-                return;
-            }
             let window_handle = match winit_state.window_map.get_mut(&window_id) {
                 Some(window_handle) => window_handle,
                 None => return,

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -170,12 +170,12 @@ impl Window {
                     use sctk::window::{Event, State};
 
                     let winit_state = dispatch_data.get::<WinitState>().unwrap();
-                    let mut window_compositor_update = winit_state
+                    let window_compositor_update = winit_state
                         .window_compositor_updates
                         .get_mut(&window_id)
                         .unwrap();
 
-                    let mut window_user_requests = winit_state
+                    let window_user_requests = winit_state
                         .window_user_requests
                         .get_mut(&window_id)
                         .unwrap();

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -128,6 +128,12 @@ impl Window {
                 let surface = event_loop_window_target
                     .env
                     .create_surface_with_scale_callback(move |scale, surface, mut dispatch_data| {
+                        // While I'm not sure how this could happen, we can safely ignore it
+                        // for now as a quickfix.
+                        if !surface.as_ref().is_alive() {
+                            return;
+                        }
+
                         let winit_state = dispatch_data.get::<WinitState>().unwrap();
 
                         // Get the window that received the event.

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -384,7 +384,7 @@ impl UnownedWindow {
                     }
                 }
 
-                let mut shared_state = window.shared_state.get_mut().unwrap();
+                let shared_state = window.shared_state.get_mut().unwrap();
                 shared_state.min_inner_size = min_inner_size.map(Into::into);
                 shared_state.max_inner_size = max_inner_size.map(Into::into);
                 shared_state.resize_increments = window_attrs.resize_increments;

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,10 +1,21 @@
 use objc2::foundation::NSObject;
 use objc2::rc::{Id, Shared};
-use objc2::runtime::Object;
+use objc2::runtime::{Object, Sel};
+use objc2::{class, sel};
 use objc2::{declare_class, msg_send, msg_send_id, ClassType};
 
-use super::app_state::AppState;
+use crate::event::{Event, MacOS, PlatformSpecific};
+use crate::platform_impl::platform::{app_state::AppState, event::EventWrapper};
+
 use super::appkit::NSApplicationActivationPolicy;
+
+/// Apple constants
+#[allow(non_upper_case_globals)]
+pub const kInternetEventClass: u32 = 0x4755524c;
+#[allow(non_upper_case_globals)]
+pub const kAEGetURL: u32 = 0x4755524c;
+#[allow(non_upper_case_globals)]
+pub const keyDirectObject: u32 = 0x2d2d2d2d;
 
 declare_class!(
     #[derive(Debug)]
@@ -46,6 +57,31 @@ declare_class!(
             );
         }
 
+        #[sel(applicationWillFinishLaunching:)]
+        fn will_finish_launching(&self, _sender: *const Object) {
+            trace!("Triggered `applicationWillFinishLaunching`");
+            unsafe {
+                let event_manager = class!(NSAppleEventManager);
+                let shared_manager: *mut Object = msg_send![event_manager, sharedAppleEventManager];
+                let () = msg_send![shared_manager,
+                    setEventHandler: self,
+                    andSelector: sel!(handleEvent:withReplyEvent:)
+                    forEventClass: kInternetEventClass
+                    andEventID: kAEGetURL
+                ];
+            }
+            trace!("Completed `applicationWillFinishLaunching`");
+        }
+
+        #[sel(handleEvent:withReplyEvent:)]
+        fn handle_url(&self, _cmd: Sel, event: *mut Object, _reply: u64) {
+            if let Some(string) = parse_url(event) {
+                AppState::queue_event(EventWrapper::StaticEvent(Event::PlatformSpecific(
+                    PlatformSpecific::MacOS(MacOS::ReceivedUrl(string)),
+                )));
+            }
+        }
+
         #[sel(applicationWillTerminate:)]
         fn will_terminate(&self, _sender: *const Object) {
             trace_scope!("applicationWillTerminate:");
@@ -68,6 +104,29 @@ impl ApplicationDelegate {
                 defaultMenu: default_menu,
                 activateIgnoringOtherApps: activate_ignoring_other_apps,
             ]
+        }
+    }
+}
+
+fn parse_url(event: *mut Object) -> Option<String> {
+    unsafe {
+        let class: u32 = msg_send![event, eventClass];
+        let id: u32 = msg_send![event, eventID];
+        if class != kInternetEventClass || id != kAEGetURL {
+            return None;
+        }
+        let subevent: *mut Object =
+            msg_send![event, paramDescriptorForKeyword: keyDirectObject];
+        let nsstring: *mut Object = msg_send![subevent, stringValue];
+        let cstr: *const i8 = msg_send![nsstring, UTF8String];
+        if !cstr.is_null() {
+            Some(
+                std::ffi::CStr::from_ptr(cstr)
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        } else {
+            None
         }
     }
 }

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,6 +1,6 @@
 use objc2::foundation::NSObject;
 use objc2::rc::{Id, Shared};
-use objc2::runtime::{Object, Sel};
+use objc2::runtime::Object;
 use objc2::{class, sel};
 use objc2::{declare_class, msg_send, msg_send_id, ClassType};
 
@@ -74,7 +74,7 @@ declare_class!(
         }
 
         #[sel(handleEvent:withReplyEvent:)]
-        fn handle_url(&self, _cmd: Sel, event: *mut Object, _reply: u64) {
+        fn handle_url(&self, event: *mut Object, _reply: u64) {
             if let Some(string) = parse_url(event) {
                 AppState::queue_event(EventWrapper::StaticEvent(Event::PlatformSpecific(
                     PlatformSpecific::MacOS(MacOS::ReceivedUrl(string)),

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,3 +1,12 @@
+use crate::event::{Event, MacOS, PlatformSpecific};
+use crate::platform::macos::ActivationPolicy;
+use crate::platform_impl::platform::{app_state::AppState, event::EventWrapper};
+use cocoa::base::id;
+use objc::{
+    declare::ClassDecl,
+    runtime::{Class, Object, Sel},
+};
+
 use std::{
     cell::{RefCell, RefMut},
     os::raw::c_void,
@@ -20,6 +29,14 @@ pub struct AuxDelegateState {
     pub activation_policy: ActivationPolicy,
     pub default_menu: bool,
 }
+
+/// Apple constants
+#[allow(non_upper_case_globals)]
+pub const kInternetEventClass: u32 = 0x4755524c;
+#[allow(non_upper_case_globals)]
+pub const kAEGetURL: u32 = 0x4755524c;
+#[allow(non_upper_case_globals)]
+pub const keyDirectObject: u32 = 0x2d2d2d2d;
 
 pub struct AppDelegateClass(pub *const Class);
 unsafe impl Send for AppDelegateClass {}
@@ -96,10 +113,10 @@ fn parse_url(event: *mut Object) -> Option<String> {
     unsafe {
         let class: u32 = msg_send![event, eventClass];
         let id: u32 = msg_send![event, eventID];
-        if class != 0x4755524c_u32 || id != 0x4755524c_u32 {
+        if class != kInternetEventClass || id != kAEGetURL {
             return None;
         }
-        let subevent: *mut Object = msg_send![event, paramDescriptorForKeyword: 0x2d2d2d2d];
+        let subevent: *mut Object = msg_send![event, paramDescriptorForKeyword: keyDirectObject];
         let nsstring: *mut Object = msg_send![subevent, stringValue];
 
         let cstr: *const i8 = msg_send![nsstring, UTF8String];
@@ -122,7 +139,9 @@ extern "C" fn handle_url(
     _reply: u64,
 ) {
     if let Some(string) = parse_url(event) {
-        AppState::queue_event(EventWrapper::StaticEvent(Event::ReceivedUrl(string)));
+        AppState::queue_event(EventWrapper::StaticEvent(Event::PlatformSpecific(
+            PlatformSpecific::MacOS(MacOS::ReceivedUrl(string)),
+        )));
     }
 }
 
@@ -134,8 +153,8 @@ extern "C" fn will_finish_launching(this: &Object, _: Sel, _: id) {
         let () = msg_send![shared_manager,
                     setEventHandler: this
                     andSelector: sel!(handleEvent:withReplyEvent:)
-                    forEventClass: 0x4755524c_u32
-                    andEventID: 0x4755524c_u32
+                    forEventClass: kInternetEventClass
+                    andEventID: kAEGetURL
         ];
     }
     trace!("Completed `applicationWillFinishLaunching`");

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -110,7 +110,7 @@ fn parse_url(event: *mut Object) -> Option<String> {
         let nsstring: *mut Object = msg_send![subevent, stringValue];
 
         let cstr: *const i8 = msg_send![nsstring, UTF8String];
-        if cstr != std::ptr::null() {
+        if !cstr.is_null() {
             Some(
                 std::ffi::CStr::from_ptr(cstr)
                     .to_string_lossy()

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,27 +1,17 @@
 use crate::event::{Event, MacOS, PlatformSpecific};
 use crate::platform::macos::ActivationPolicy;
 use crate::platform_impl::platform::{app_state::AppState, event::EventWrapper};
-use cocoa::base::id;
-use objc::{
-    declare::ClassDecl,
-    runtime::{Class, Object, Sel},
-};
 
-use std::{
-    cell::{RefCell, RefMut},
-    os::raw::c_void,
-};
-
-use crate::platform_impl::platform::{app_state::AppState, event::EventWrapper};
-use crate::{event::Event, platform::macos::ActivationPolicy};
 use cocoa::base::id;
 use objc::{
     declare::ClassDecl,
     runtime::{Class, Object, Sel},
 };
 use once_cell::sync::Lazy;
-
-use crate::{platform::macos::ActivationPolicy, platform_impl::platform::app_state::AppState};
+use std::{
+    cell::{RefCell, RefMut},
+    os::raw::c_void,
+};
 
 static AUX_DELEGATE_STATE_NAME: &str = "auxState";
 

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -3,6 +3,8 @@ use std::{
     os::raw::c_void,
 };
 
+use crate::platform_impl::platform::{app_state::AppState, event::EventWrapper};
+use crate::{event::Event, platform::macos::ActivationPolicy};
 use cocoa::base::id;
 use objc::{
     declare::ClassDecl,
@@ -31,12 +33,26 @@ pub static APP_DELEGATE_CLASS: Lazy<AppDelegateClass> = Lazy::new(|| unsafe {
     decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
 
     decl.add_method(
+        sel!(applicationWillFinishLaunching:),
+        will_finish_launching as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
         sel!(applicationDidFinishLaunching:),
         did_finish_launching as extern "C" fn(&Object, Sel, id),
     );
     decl.add_method(
         sel!(applicationWillTerminate:),
         will_terminate as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(handleEvent:withReplyEvent:),
+        handle_url
+            as extern "C" fn(
+                &objc::runtime::Object,
+                _cmd: objc::runtime::Sel,
+                event: *mut Object,
+                _reply: u64,
+            ),
     );
 
     decl.add_ivar::<*mut c_void>(AUX_DELEGATE_STATE_NAME);
@@ -74,6 +90,55 @@ extern "C" fn dealloc(this: &Object, _: Sel) {
         // memory
         drop(Box::from_raw(state_ptr as *mut RefCell<AuxDelegateState>));
     }
+}
+
+fn parse_url(event: *mut Object) -> Option<String> {
+    unsafe {
+        let class: u32 = msg_send![event, eventClass];
+        let id: u32 = msg_send![event, eventID];
+        if class != 0x4755524c_u32 || id != 0x4755524c_u32 {
+            return None;
+        }
+        let subevent: *mut Object = msg_send![event, paramDescriptorForKeyword: 0x2d2d2d2d];
+        let nsstring: *mut Object = msg_send![subevent, stringValue];
+
+        let cstr: *const i8 = msg_send![nsstring, UTF8String];
+        if cstr != std::ptr::null() {
+            Some(
+                std::ffi::CStr::from_ptr(cstr)
+                    .to_string_lossy()
+                    .into_owned(),
+            )
+        } else {
+            None
+        }
+    }
+}
+
+extern "C" fn handle_url(
+    _this: &objc::runtime::Object,
+    _cmd: objc::runtime::Sel,
+    event: *mut Object,
+    _reply: u64,
+) {
+    if let Some(string) = parse_url(event) {
+        AppState::queue_event(EventWrapper::StaticEvent(Event::ReceivedUrl(string)));
+    }
+}
+
+extern "C" fn will_finish_launching(this: &Object, _: Sel, _: id) {
+    trace!("Triggered `applicationWillFinishLaunching`");
+    unsafe {
+        let event_manager = class!(NSAppleEventManager);
+        let shared_manager: *mut Object = msg_send![event_manager, sharedAppleEventManager];
+        let () = msg_send![shared_manager,
+                    setEventHandler: this
+                    andSelector: sel!(handleEvent:withReplyEvent:)
+                    forEventClass: 0x4755524c_u32
+                    andEventID: 0x4755524c_u32
+        ];
+    }
+    trace!("Completed `applicationWillFinishLaunching`");
 }
 
 extern "C" fn did_finish_launching(this: &Object, _: Sel, _: id) {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -466,6 +466,10 @@ impl WinitWindow {
 
         let delegate = WinitWindowDelegate::new(&this, attrs.fullscreen.is_some());
 
+        // XXX Send `Focused(false)` right after creating the window delegate, so we won't
+        // obscure the real focused events on the startup.
+        delegate.queue_event(WindowEvent::Focused(false));
+
         // Set fullscreen mode after we setup everything
         this.set_fullscreen(attrs.fullscreen.map(Into::into));
 
@@ -484,8 +488,6 @@ impl WinitWindow {
         if attrs.maximized {
             this.set_maximized(attrs.maximized);
         }
-
-        delegate.queue_event(WindowEvent::Focused(false));
 
         Ok((this, delegate))
     }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -3,7 +3,7 @@
 use std::ptr;
 
 use objc2::declare::{Ivar, IvarDrop};
-use objc2::foundation::{NSArray, NSObject, NSString};
+use objc2::foundation::{NSArray, NSObject, NSSize, NSString};
 use objc2::rc::{autoreleasepool, Id, Shared};
 use objc2::runtime::Object;
 use objc2::{class, declare_class, msg_send, msg_send_id, sel, ClassType};
@@ -115,6 +115,23 @@ declare_class!(
             trace_scope!("windowDidResize:");
             // NOTE: WindowEvent::Resized is reported in frameDidChange.
             self.emit_move_event();
+        }
+
+        #[sel(windowWillStartLiveResize:)]
+        fn window_will_start_live_resize(&mut self, _: Option<&Object>) {
+            trace_scope!("windowWillStartLiveResize:");
+
+            let increments = self
+                .window
+                .lock_shared_state("window_will_enter_fullscreen")
+                .resize_increments;
+            self.window.set_resize_increments_inner(increments);
+        }
+
+        #[sel(windowDidEndLiveResize:)]
+        fn window_did_end_live_resize(&mut self, _: Option<&Object>) {
+            trace_scope!("windowDidEndLiveResize:");
+            self.window.set_resize_increments_inner(NSSize::new(1., 1.));
         }
 
         // This won't be triggered if the move was part of a resize.

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -281,25 +281,7 @@ declare_class!(
             proposed_options: NSApplicationPresentationOptions,
         ) -> NSApplicationPresentationOptions {
             trace_scope!("window:willUseFullScreenPresentationOptions:");
-            // Generally, games will want to disable the menu bar and the dock. Ideally,
-            // this would be configurable by the user. Unfortunately because of our
-            // `CGShieldingWindowLevel() + 1` hack (see `set_fullscreen`), our window is
-            // placed on top of the menu bar in exclusive fullscreen mode. This looks
-            // broken so we always disable the menu bar in exclusive fullscreen. We may
-            // still want to make this configurable for borderless fullscreen. Right now
-            // we don't, for consistency. If we do, it should be documented that the
-            // user-provided options are ignored in exclusive fullscreen.
-            let mut options = proposed_options;
-            let shared_state = self
-                .window
-                .lock_shared_state("window_will_use_fullscreen_presentation_options");
-            if let Some(Fullscreen::Exclusive(_)) = shared_state.fullscreen {
-                options = NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
-                    | NSApplicationPresentationOptions::NSApplicationPresentationHideDock
-                    | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar;
-            }
-
-            options
+            proposed_options
         }
 
         /// Invoked when entered fullscreen

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -460,30 +460,7 @@ extern "C" fn window_will_use_fullscreen_presentation_options(
     _: id,
     proposed_options: NSUInteger,
 ) -> NSUInteger {
-    trace_scope!("window:willUseFullScreenPresentationOptions:");
-    // Generally, games will want to disable the menu bar and the dock. Ideally,
-    // this would be configurable by the user. Unfortunately because of our
-    // `CGShieldingWindowLevel() + 1` hack (see `set_fullscreen`), our window is
-    // placed on top of the menu bar in exclusive fullscreen mode. This looks
-    // broken so we always disable the menu bar in exclusive fullscreen. We may
-    // still want to make this configurable for borderless fullscreen. Right now
-    // we don't, for consistency. If we do, it should be documented that the
-    // user-provided options are ignored in exclusive fullscreen.
-    let mut options: NSUInteger = proposed_options;
-    with_state(this, |state| {
-        state.with_window(|window| {
-            let shared_state =
-                window.lock_shared_state("window_will_use_fullscreen_presentation_options");
-            if let Some(Fullscreen::Exclusive(_)) = shared_state.fullscreen {
-                options = (NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
-                    | NSApplicationPresentationOptions::NSApplicationPresentationHideDock
-                    | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar)
-                    .bits();
-            }
-        })
-    });
-
-    options
+    proposed_options
 }
 
 /// Invoked when entered fullscreen

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use cocoa::{
-    appkit::{self, NSApplicationPresentationOptions, NSView, NSWindow, NSWindowOcclusionState},
+    appkit::{self, NSView, NSWindow, NSWindowOcclusionState},
     base::{id, nil},
     foundation::NSUInteger,
 };

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -455,7 +455,7 @@ extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
 }
 
 extern "C" fn window_will_use_fullscreen_presentation_options(
-    this: &Object,
+    _this: &Object,
     _: Sel,
     _: id,
     proposed_options: NSUInteger,

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -409,7 +409,20 @@ impl Window {
 
     #[inline]
     pub fn theme(&self) -> Option<Theme> {
-        None
+        web_sys::window()
+            .and_then(|window| {
+                window
+                    .match_media("(prefers-color-scheme: dark)")
+                    .ok()
+                    .flatten()
+            })
+            .map(|media_query_list| {
+                if media_query_list.matches() {
+                    Theme::Dark
+                } else {
+                    Theme::Light
+                }
+            })
     }
 
     #[inline]

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -205,7 +205,10 @@ impl<T: 'static> EventLoop<T> {
 
         let thread_msg_target = create_event_target_window::<T>();
 
-        thread::spawn(move || wait_thread(thread_id, thread_msg_target));
+        thread::Builder::new()
+            .name("winit wait thread".to_string())
+            .spawn(move || wait_thread(thread_id, thread_msg_target))
+            .expect("Failed to spawn winit wait thread");
         let wait_thread_id = get_wait_thread_id();
 
         let runner_shared = Rc::new(EventLoopRunner::new(thread_msg_target, wait_thread_id));

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -10,6 +10,7 @@ use std::{
     mem, panic, ptr,
     rc::Rc,
     sync::{
+        atomic::{AtomicU32, Ordering},
         mpsc::{self, Receiver, Sender},
         Arc, Mutex, MutexGuard,
     },
@@ -382,11 +383,12 @@ fn get_wait_thread_id() -> u32 {
         let result = GetMessageW(
             &mut msg,
             -1,
-            *SEND_WAIT_THREAD_ID_MSG_ID,
-            *SEND_WAIT_THREAD_ID_MSG_ID,
+            SEND_WAIT_THREAD_ID_MSG_ID.get(),
+            SEND_WAIT_THREAD_ID_MSG_ID.get(),
         );
         assert_eq!(
-            msg.message, *SEND_WAIT_THREAD_ID_MSG_ID,
+            msg.message,
+            SEND_WAIT_THREAD_ID_MSG_ID.get(),
             "this shouldn't be possible. please open an issue with Winit. error code: {result}"
         );
         msg.lParam as u32
@@ -412,7 +414,7 @@ fn wait_thread(parent_thread_id: u32, msg_window_id: HWND) {
         let cur_thread_id = GetCurrentThreadId();
         PostThreadMessageW(
             parent_thread_id,
-            *SEND_WAIT_THREAD_ID_MSG_ID,
+            SEND_WAIT_THREAD_ID_MSG_ID.get(),
             0,
             cur_thread_id as LPARAM,
         );
@@ -436,9 +438,9 @@ fn wait_thread(parent_thread_id: u32, msg_window_id: HWND) {
                 DispatchMessageW(&msg);
             }
 
-            if msg.message == *WAIT_UNTIL_MSG_ID {
+            if msg.message == WAIT_UNTIL_MSG_ID.get() {
                 wait_until_opt = Some(*WaitUntilInstantBox::from_raw(msg.lParam as *mut _));
-            } else if msg.message == *CANCEL_WAIT_UNTIL_MSG_ID {
+            } else if msg.message == CANCEL_WAIT_UNTIL_MSG_ID.get() {
                 wait_until_opt = None;
             }
 
@@ -466,11 +468,11 @@ fn wait_thread(parent_thread_id: u32, msg_window_id: HWND) {
                         timeEndPeriod(period);
                     }
                     if resume_reason == WAIT_TIMEOUT {
-                        PostMessageW(msg_window_id, *PROCESS_NEW_EVENTS_MSG_ID, 0, 0);
+                        PostMessageW(msg_window_id, PROCESS_NEW_EVENTS_MSG_ID.get(), 0, 0);
                         wait_until_opt = None;
                     }
                 } else {
-                    PostMessageW(msg_window_id, *PROCESS_NEW_EVENTS_MSG_ID, 0, 0);
+                    PostMessageW(msg_window_id, PROCESS_NEW_EVENTS_MSG_ID.get(), 0, 0);
                     wait_until_opt = None;
                 }
             }
@@ -556,7 +558,7 @@ impl EventLoopThreadExecutor {
 
                 let raw = Box::into_raw(boxed2);
 
-                let res = PostMessageW(self.target_window, *EXEC_MSG_ID, raw as usize, 0);
+                let res = PostMessageW(self.target_window, EXEC_MSG_ID.get(), raw as usize, 0);
                 assert!(
                     res != false.into(),
                     "PostMessage failed; is the messages queue full?"
@@ -586,7 +588,7 @@ impl<T: 'static> Clone for EventLoopProxy<T> {
 impl<T: 'static> EventLoopProxy<T> {
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
         unsafe {
-            if PostMessageW(self.target_window, *USER_EVENT_MSG_ID, 0, 0) != false.into() {
+            if PostMessageW(self.target_window, USER_EVENT_MSG_ID.get(), 0, 0) != false.into() {
                 self.event_send.send(event).ok();
                 Ok(())
             } else {
@@ -598,40 +600,84 @@ impl<T: 'static> EventLoopProxy<T> {
 
 type WaitUntilInstantBox = Box<Instant>;
 
+/// A lazily-initialized window message ID.
+pub struct LazyMessageId {
+    /// The ID.
+    id: AtomicU32,
+
+    /// The name of the message.
+    name: &'static str,
+}
+
+/// An invalid custom window ID.
+const INVALID_ID: u32 = 0x0;
+
+impl LazyMessageId {
+    /// Create a new `LazyId`.
+    const fn new(name: &'static str) -> Self {
+        Self {
+            id: AtomicU32::new(INVALID_ID),
+            name,
+        }
+    }
+
+    /// Get the message ID.
+    pub fn get(&self) -> u32 {
+        // Load the ID.
+        let id = self.id.load(Ordering::Relaxed);
+
+        if id != INVALID_ID {
+            return id;
+        }
+
+        // Register the message.
+        // SAFETY: We are sure that the pointer is a valid C string ending with '\0'.
+        assert!(self.name.ends_with('\0'));
+        let new_id = unsafe { RegisterWindowMessageA(self.name.as_ptr()) };
+
+        assert_ne!(
+            new_id,
+            0,
+            "RegisterWindowMessageA returned zero for '{}': {}",
+            self.name,
+            std::io::Error::last_os_error()
+        );
+
+        // Store the new ID. Since `RegisterWindowMessageA` returns the same value for any given string,
+        // the target value will always either be a). `INVALID_ID` or b). the correct ID. Therefore a
+        // compare-and-swap operation here (or really any consideration) is never necessary.
+        self.id.store(new_id, Ordering::Relaxed);
+
+        new_id
+    }
+}
+
 // Message sent by the `EventLoopProxy` when we want to wake up the thread.
 // WPARAM and LPARAM are unused.
-static USER_EVENT_MSG_ID: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("Winit::WakeupMsg\0".as_ptr()) });
+static USER_EVENT_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::WakeupMsg\0");
 // Message sent when we want to execute a closure in the thread.
 // WPARAM contains a Box<Box<dyn FnMut()>> that must be retrieved with `Box::from_raw`,
 // and LPARAM is unused.
-static EXEC_MSG_ID: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("Winit::ExecMsg\0".as_ptr()) });
-static PROCESS_NEW_EVENTS_MSG_ID: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("Winit::ProcessNewEvents\0".as_ptr()) });
+static EXEC_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::ExecMsg\0");
+static PROCESS_NEW_EVENTS_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::ProcessNewEvents\0");
 /// lparam is the wait thread's message id.
-static SEND_WAIT_THREAD_ID_MSG_ID: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("Winit::SendWaitThreadId\0".as_ptr()) });
+static SEND_WAIT_THREAD_ID_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::SendWaitThreadId\0");
 /// lparam points to a `Box<Instant>` signifying the time `PROCESS_NEW_EVENTS_MSG_ID` should
 /// be sent.
-static WAIT_UNTIL_MSG_ID: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("Winit::WaitUntil\0".as_ptr()) });
-static CANCEL_WAIT_UNTIL_MSG_ID: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("Winit::CancelWaitUntil\0".as_ptr()) });
+static WAIT_UNTIL_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::WaitUntil\0");
+static CANCEL_WAIT_UNTIL_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::CancelWaitUntil\0");
 // Message sent by a `Window` when it wants to be destroyed by the main thread.
 // WPARAM and LPARAM are unused.
-pub static DESTROY_MSG_ID: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("Winit::DestroyMsg\0".as_ptr()) });
+pub static DESTROY_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::DestroyMsg\0");
 // WPARAM is a bool specifying the `WindowFlags::MARKER_RETAIN_STATE_ON_SIZE` flag. See the
 // documentation in the `window_state` module for more information.
-pub static SET_RETAIN_STATE_ON_SIZE_MSG_ID: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("Winit::SetRetainMaximized\0".as_ptr()) });
+pub static SET_RETAIN_STATE_ON_SIZE_MSG_ID: LazyMessageId =
+    LazyMessageId::new("Winit::SetRetainMaximized\0");
 static THREAD_EVENT_TARGET_WINDOW_CLASS: Lazy<Vec<u16>> =
     Lazy::new(|| util::encode_wide("Winit Thread Event Target"));
 /// When the taskbar is created, it registers a message with the "TaskbarCreated" string and then broadcasts this message to all top-level windows
 /// <https://docs.microsoft.com/en-us/windows/win32/shell/taskbar#taskbar-creation-notification>
-pub static TASKBAR_CREATED: Lazy<u32> =
-    Lazy::new(|| unsafe { RegisterWindowMessageA("TaskbarCreated\0".as_ptr()) });
+pub static TASKBAR_CREATED: LazyMessageId = LazyMessageId::new("TaskbarCreated\0");
 
 fn create_event_target_window<T: 'static>() -> HWND {
     use windows_sys::Win32::UI::WindowsAndMessaging::CS_HREDRAW;
@@ -783,13 +829,18 @@ unsafe fn flush_paint_messages<T: 'static>(
 unsafe fn process_control_flow<T: 'static>(runner: &EventLoopRunner<T>) {
     match runner.control_flow() {
         ControlFlow::Poll => {
-            PostMessageW(runner.thread_msg_target(), *PROCESS_NEW_EVENTS_MSG_ID, 0, 0);
+            PostMessageW(
+                runner.thread_msg_target(),
+                PROCESS_NEW_EVENTS_MSG_ID.get(),
+                0,
+                0,
+            );
         }
         ControlFlow::Wait => (),
         ControlFlow::WaitUntil(until) => {
             PostThreadMessageW(
                 runner.wait_thread_id(),
-                *WAIT_UNTIL_MSG_ID,
+                WAIT_UNTIL_MSG_ID.get(),
                 0,
                 Box::into_raw(WaitUntilInstantBox::new(until)) as isize,
             );
@@ -2244,16 +2295,16 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         _ => {
-            if msg == *DESTROY_MSG_ID {
+            if msg == DESTROY_MSG_ID.get() {
                 DestroyWindow(window);
                 0
-            } else if msg == *SET_RETAIN_STATE_ON_SIZE_MSG_ID {
+            } else if msg == SET_RETAIN_STATE_ON_SIZE_MSG_ID.get() {
                 let mut window_state = userdata.window_state_lock();
                 window_state.set_window_flags_in_place(|f| {
                     f.set(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE, wparam != 0)
                 });
                 0
-            } else if msg == *TASKBAR_CREATED {
+            } else if msg == TASKBAR_CREATED.get() {
                 let window_state = userdata.window_state_lock();
                 set_skip_taskbar(window, window_state.skip_taskbar);
                 DefWindowProcW(window, msg, wparam, lparam)
@@ -2442,21 +2493,21 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             DefWindowProcW(window, msg, wparam, lparam)
         }
 
-        _ if msg == *USER_EVENT_MSG_ID => {
+        _ if msg == USER_EVENT_MSG_ID.get() => {
             if let Ok(event) = userdata.user_event_receiver.recv() {
                 userdata.send_event(Event::UserEvent(event));
             }
             0
         }
-        _ if msg == *EXEC_MSG_ID => {
+        _ if msg == EXEC_MSG_ID.get() => {
             let mut function: ThreadExecFn = Box::from_raw(wparam as *mut _);
             function();
             0
         }
-        _ if msg == *PROCESS_NEW_EVENTS_MSG_ID => {
+        _ if msg == PROCESS_NEW_EVENTS_MSG_ID.get() => {
             PostThreadMessageW(
                 userdata.event_loop_runner.wait_thread_id(),
-                *CANCEL_WAIT_UNTIL_MSG_ID,
+                CANCEL_WAIT_UNTIL_MSG_ID.get(),
                 0,
                 0,
             );

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -841,7 +841,7 @@ impl Drop for Window {
         unsafe {
             // The window must be destroyed from the same thread that created it, so we send a
             // custom message to be handled by our callback to do the actual work.
-            PostMessageW(self.hwnd(), *DESTROY_MSG_ID, 0, 0);
+            PostMessageW(self.hwnd(), DESTROY_MSG_ID.get(), 0, 0);
         }
     }
 }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -391,7 +391,12 @@ impl WindowFlags {
             let (style, style_ex) = new.to_window_styles();
 
             unsafe {
-                SendMessageW(window, *event_loop::SET_RETAIN_STATE_ON_SIZE_MSG_ID, 1, 0);
+                SendMessageW(
+                    window,
+                    event_loop::SET_RETAIN_STATE_ON_SIZE_MSG_ID.get(),
+                    1,
+                    0,
+                );
 
                 // This condition is necessary to avoid having an unrestorable window
                 if !new.contains(WindowFlags::MINIMIZED) {
@@ -412,7 +417,12 @@ impl WindowFlags {
 
                 // Refresh the window frame
                 SetWindowPos(window, 0, 0, 0, 0, 0, flags);
-                SendMessageW(window, *event_loop::SET_RETAIN_STATE_ON_SIZE_MSG_ID, 0, 0);
+                SendMessageW(
+                    window,
+                    event_loop::SET_RETAIN_STATE_ON_SIZE_MSG_ID.get(),
+                    0,
+                    0,
+                );
             }
         }
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1299,6 +1299,7 @@ impl Window {
     /// [`EventLoopWindowTarget::available_monitors`]: crate::event_loop::EventLoopWindowTarget::available_monitors
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
+        #[allow(clippy::useless_conversion)]
         self.window
             .available_monitors()
             .into_iter()

--- a/src/window.rs
+++ b/src/window.rs
@@ -1126,7 +1126,7 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **macOS:** This is an app-wide setting.
-    /// - **iOS / Android / Web / Wayland / x11 / Orbital:** Unsupported.
+    /// - **iOS / Android / Wayland / x11 / Orbital:** Unsupported.
     #[inline]
     pub fn theme(&self) -> Option<Theme> {
         self.window.theme()


### PR DESCRIPTION
This was a *little* tricky because winit has switched from the `objc` crate to `objc2`. So our patch had to be updated. I *think * I've got everything from the earlier commit, but merging the app_delegate was done manually, so I could have missed something. I've currently checked that it compiles, but I haven't yet checked that it still works.

I haven't included the patch to remove `1.59.0` from CI because I wasn't sure on the logic behind that. Upstream winit is now  pinning to `1.60.0`, and is using stable linting (which was the other change in Iced's patch).