### PR TITLE
remove .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/apk-builder"]
-	path = deps/apk-builder
-	url = https://github.com/rust-windowing/android-rs-glue


### PR DESCRIPTION
I've successfully built an iced app w/ Flatpak. However, it fails when this .gitmodules file is present since the entry is no longer valid. It is safe to remove this file since there are no more submodules.