### PR TITLE
Fix reentrant thread callback on Win32.

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2538,7 +2538,9 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                     }
                 }
             }
-            userdata.event_loop_runner.poll();
+            if !userdata.event_loop_runner.should_buffer() {
+                userdata.event_loop_runner.poll();
+            }
             0
         }
         _ => DefWindowProcW(window, msg, wparam, lparam),


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
