### PR TITLE
Port fix for rust-windowing/winit/issues/2291

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows, fix re-entrant event loop crash from rust-windowing/winit/issues/2291
+
 # 0.28.6
 
 - On macOS, fixed memory leak when getting monitor handle.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2538,7 +2538,9 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                     }
                 }
             }
-            userdata.event_loop_runner.poll();
+            if !userdata.event_loop_runner.should_buffer() {
+                userdata.event_loop_runner.poll();
+            }
             0
         }
         _ => DefWindowProcW(window, msg, wparam, lparam),


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Change affects Windows platform only.

This is a prospective fix ported from the [original issue](https://github.com/rust-windowing/winit/issues/2291).  Observed this to fix the problem of launching a dialog (e.g. `rfd::FileDialog`) sometimes crashing an `iced` application.  With fix in place, crash no longer occurs.  Because the dialog essentially runs a new pump and blocks the main thread, the application will not receive other messages (such as those sent from background threads).  These messages are observed to get queued up and then delivered once the dialog is closed and the main thread pump resumes.  I do not know if this is the desired behavior or if a more main-event-loop friendly way of handling these kinds of dialogs is something that can be done. 