### PR TITLE
Update to v0.30.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-  push:
-    branches: [master]
-
+on: [pull_request, push]
 jobs:
   fmt:
     name: Check formatting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, nightly, '1.70.0']
+        toolchain: [stable, '1.70.0']
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
           - { name: 'Windows 64bit MSVC', target: x86_64-pc-windows-msvc,   os: windows-latest,  }

--- a/src/application.rs
+++ b/src/application.rs
@@ -222,6 +222,15 @@ pub trait ApplicationHandler<T: 'static = ()> {
     fn memory_warning(&mut self, event_loop: &ActiveEventLoop) {
         let _ = event_loop;
     }
+
+    /// Emitted when the application has received a URL, through a
+    /// custom URL handler.
+    ///
+    /// Only supported on macOS.
+    fn received_url(&mut self, event_loop: &ActiveEventLoop, url: String) {
+        let _ = event_loop;
+        let _ = url;
+    }
 }
 
 impl<A: ?Sized + ApplicationHandler<T>, T: 'static> ApplicationHandler<T> for &mut A {

--- a/src/event.rs
+++ b/src/event.rs
@@ -103,6 +103,21 @@ pub enum Event<T: 'static> {
     ///
     /// [`ApplicationHandler::memory_warning`]: crate::application::ApplicationHandler::memory_warning
     MemoryWarning,
+
+    /// Emitted when the event loop receives an event that only occurs on some specific platform.
+    PlatformSpecific(PlatformSpecific),
+}
+
+/// Describes an event from some specific platform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlatformSpecific {
+    MacOS(MacOS),
+}
+
+/// Describes an event that only happens in `MacOS`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacOS {
+    ReceivedUrl(String),
 }
 
 impl<T> Event<T> {
@@ -119,6 +134,7 @@ impl<T> Event<T> {
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
             MemoryWarning => Ok(MemoryWarning),
+            PlatformSpecific(event) => Ok(PlatformSpecific(event)),
         }
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -20,7 +20,7 @@ use web_time::{Duration, Instant};
 
 use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, OsError};
-use crate::event::Event;
+use crate::event::{self, Event};
 use crate::monitor::MonitorHandle;
 use crate::platform_impl;
 use crate::window::{CustomCursor, CustomCursorSource, Window, WindowAttributes};
@@ -636,5 +636,8 @@ pub(crate) fn dispatch_event_for_app<T: 'static, A: ApplicationHandler<T>>(
         Event::AboutToWait => app.about_to_wait(event_loop),
         Event::LoopExiting => app.exiting(event_loop),
         Event::MemoryWarning => app.memory_warning(event_loop),
+        Event::PlatformSpecific(event::PlatformSpecific::MacOS(event::MacOS::ReceivedUrl(url))) => {
+            app.received_url(event_loop, url)
+        },
     }
 }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -781,10 +781,13 @@ impl WindowDelegate {
 
         let suggested_size = content_size.to_physical(scale_factor);
         let new_inner_size = Arc::new(Mutex::new(suggested_size));
-        app_delegate.handle_window_event(window.id(), WindowEvent::ScaleFactorChanged {
-            scale_factor,
-            inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
-        });
+        app_delegate.handle_window_event(
+            window.id(),
+            WindowEvent::ScaleFactorChanged {
+                scale_factor,
+                inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
+            },
+        );
         let physical_size = *new_inner_size.lock().unwrap();
         drop(new_inner_size);
 


### PR DESCRIPTION
This PR updates this fork from winit v0.30.1 to v0.30.8. This brings several bug fixes including the fix for https://github.com/iced-rs/iced/issues/2727.

https://docs.rs/winit/latest/winit/changelog/index.html

This PR just merges the upstream's [v0.30.8](https://github.com/rust-windowing/winit/tree/v0.30.8) tag into the v0.30.x branch. The conflict was very small so I manually fixed it and checked some examples in iced-rs/iced:

```
<<<<<<< HEAD
use objc2::runtime::AnyObject;
use objc2::{
    class, declare_class, msg_send, msg_send_id, mutability, sel, ClassType, DeclaredClass,
};
use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate};
||||||| 437747b9
use objc2::{declare_class, msg_send_id, mutability, ClassType, DeclaredClass};
use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate};
=======
use objc2::{declare_class, msg_send_id, mutability, ClassType, DeclaredClass};
use objc2_app_kit::{
    NSApplication, NSApplicationActivationPolicy, NSApplicationDelegate, NSRunningApplication,
};
>>>>>>> v0.30.8
```

Fixes iced-rs/iced#2727