### PR TITLE
[WASM] Add support for IME

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,7 @@ web_sys = { package = "web-sys", version = "0.3.70", features = [
     "Blob",
     "BlobPropertyBag",
     "console",
+    "CompositionEvent",
     "CssStyleDeclaration",
     "Document",
     "DomException",

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -39,3 +39,7 @@ The migration guide could reference other migration examples in the current
 changelog entry.
 
 ## Unreleased
+
+### Added
+
+- Implement IME support for the web platform, for browser supporting the EditContext API.

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -823,10 +823,13 @@ impl WindowDelegate {
 
         let suggested_size = content_size.to_physical(scale_factor);
         let new_inner_size = Arc::new(Mutex::new(suggested_size));
-        app_delegate.handle_window_event(window.id(), WindowEvent::ScaleFactorChanged {
-            scale_factor,
-            inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
-        });
+        app_delegate.handle_window_event(
+            window.id(),
+            WindowEvent::ScaleFactorChanged {
+                scale_factor,
+                inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
+            },
+        );
         let physical_size = *new_inner_size.lock().unwrap();
         drop(new_inner_size);
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -823,13 +823,10 @@ impl WindowDelegate {
 
         let suggested_size = content_size.to_physical(scale_factor);
         let new_inner_size = Arc::new(Mutex::new(suggested_size));
-        app_delegate.handle_window_event(
-            window.id(),
-            WindowEvent::ScaleFactorChanged {
-                scale_factor,
-                inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
-            },
-        );
+        app_delegate.handle_window_event(window.id(), WindowEvent::ScaleFactorChanged {
+            scale_factor,
+            inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
+        });
         let physical_size = *new_inner_size.lock().unwrap();
         drop(new_inner_size);
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -605,6 +605,10 @@ impl ActiveEventLoop {
                 if let Some(data) = data {
                     runner.send_event(Event::WindowEvent {
                         window_id: RootWindowId(id),
+                        event: WindowEvent::Ime(Ime::Preedit(String::new(), None)),
+                    });
+                    runner.send_event(Event::WindowEvent {
+                        window_id: RootWindowId(id),
                         event: WindowEvent::Ime(Ime::Commit(data)),
                     });
                 }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -14,7 +14,7 @@ use super::runner::{EventWrapper, Execution};
 use super::window::WindowId;
 use super::{backend, runner};
 use crate::event::{
-    DeviceId as RootDeviceId, ElementState, Event, KeyEvent, Touch, TouchPhase, WindowEvent,
+    DeviceId as RootDeviceId, ElementState, Event, Ime, KeyEvent, Touch, TouchPhase, WindowEvent,
 };
 use crate::event_loop::{ControlFlow, DeviceEvents};
 use crate::keyboard::ModifiersState;
@@ -586,6 +586,42 @@ impl ActiveEventLoop {
         canvas.on_animation_frame(move || runner.request_redraw(RootWindowId(id)));
 
         canvas.on_context_menu();
+
+        canvas.on_composition_start({
+            let runner = self.runner.clone();
+            move |data, position| {
+                if let Some(data) = data {
+                    runner.send_event(Event::WindowEvent {
+                        window_id: RootWindowId(id),
+                        event: WindowEvent::Ime(Ime::Preedit(data, position)),
+                    });
+                }
+            }
+        });
+
+        canvas.on_composition_end({
+            let runner = self.runner.clone();
+            move |data| {
+                if let Some(data) = data {
+                    runner.send_event(Event::WindowEvent {
+                        window_id: RootWindowId(id),
+                        event: WindowEvent::Ime(Ime::Commit(data)),
+                    });
+                }
+            }
+        });
+
+        canvas.on_text_update({
+            let runner = self.runner.clone();
+            move |data, position| {
+                if let Some(data) = data {
+                    runner.send_event(Event::WindowEvent {
+                        window_id: RootWindowId(id),
+                        event: WindowEvent::Ime(Ime::Preedit(data, position)),
+                    });
+                }
+            }
+        });
     }
 
     pub fn available_monitors(&self) -> VecDequeIter<MonitorHandle> {

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -3,12 +3,13 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use js_sys::{Array, Function, Reflect};
 use smol_str::SmolStr;
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen::JsCast;
+use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{
-    CssStyleDeclaration, Document, Event, FocusEvent, HtmlCanvasElement, KeyboardEvent,
-    PointerEvent, WheelEvent,
+    CompositionEvent, CssStyleDeclaration, Document, Event, EventTarget, FocusEvent,
+    HtmlCanvasElement, KeyboardEvent, PointerEvent, WheelEvent,
 };
 
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
@@ -48,6 +49,9 @@ pub struct Canvas {
     animation_frame_handler: AnimationFrameHandler,
     on_touch_end: Option<EventListenerHandle<dyn FnMut(Event)>>,
     on_context_menu: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
+    on_composition_start: Option<EventListenerHandle<dyn FnMut(CompositionEvent)>>,
+    on_composition_end: Option<EventListenerHandle<dyn FnMut(CompositionEvent)>>,
+    on_text_update: Option<EventListenerHandle<dyn FnMut(Event)>>,
     pub cursor: CursorHandler,
 }
 
@@ -58,6 +62,13 @@ pub struct Common {
     /// the DPI factor is maintained. Note: this is read-only because we use a pointer to this
     /// for [`WindowHandle`][rwh_06::WindowHandle].
     raw: Rc<HtmlCanvasElement>,
+    /// Owned `EditContext` instance, if the browser supports it
+    /// (Chromium 121+). When `Some`, IME events are routed through
+    /// it instead of through canvas keyboard events, which lets
+    /// the OS IME composition (CJK, Indic, etc.) hand committed
+    /// text into a wgpu canvas. `None` on non-Chromium browsers
+    /// — IME is unavailable there.
+    raw_edit_context: Option<Rc<JsValue>>,
     style: Style,
     old_size: Rc<Cell<PhysicalSize<u32>>>,
     current_size: Rc<Cell<PhysicalSize<u32>>>,
@@ -112,10 +123,21 @@ impl Canvas {
 
         let cursor = CursorHandler::new(main_thread, canvas.clone(), style.clone());
 
+        // Optional EditContext for IME (Chromium 121+). Other
+        // browsers leave this `None` and IME stays unavailable.
+        let edit_context = Reflect::get(&window, &JsValue::from_str("EditContext"))
+            .ok()
+            .filter(|v| !v.is_undefined())
+            .and_then(|ctor| {
+                let ctor: &Function = ctor.unchecked_ref();
+                Reflect::construct(ctor, &Array::new()).ok()
+            });
+
         let common = Common {
             window: window.clone(),
             document: document.clone(),
             raw: Rc::new(canvas.clone()),
+            raw_edit_context: edit_context.map(Rc::new),
             style,
             old_size: Rc::default(),
             current_size: Rc::default(),
@@ -168,6 +190,9 @@ impl Canvas {
             animation_frame_handler: AnimationFrameHandler::new(window),
             on_touch_end: None,
             on_context_menu: None,
+            on_composition_start: None,
+            on_composition_end: None,
+            on_text_update: None,
             cursor,
         })
     }
@@ -441,6 +466,125 @@ impl Canvas {
             }));
     }
 
+    pub(crate) fn on_composition_start<F>(&mut self, mut handler: F)
+    where
+        F: 'static + FnMut(Option<String>, Option<(usize, usize)>),
+    {
+        let prevent_default = Rc::clone(&self.prevent_default);
+        self.on_composition_start =
+            self.common.add_ime_event("compositionstart", move |event: CompositionEvent| {
+                if prevent_default.get() {
+                    event.prevent_default();
+                }
+                handler(event.data(), None);
+            });
+    }
+
+    pub(crate) fn on_composition_end<F>(&mut self, mut handler: F)
+    where
+        F: 'static + FnMut(Option<String>),
+    {
+        let prevent_default = Rc::clone(&self.prevent_default);
+        self.on_composition_end =
+            self.common.add_ime_event("compositionend", move |event: CompositionEvent| {
+                if prevent_default.get() {
+                    event.prevent_default();
+                }
+                handler(event.data());
+            });
+    }
+
+    pub(crate) fn on_text_update<F>(&mut self, mut handler: F)
+    where
+        F: 'static + FnMut(Option<String>, Option<(usize, usize)>),
+    {
+        let prevent_default = Rc::clone(&self.prevent_default);
+        self.on_text_update = self.common.add_ime_event("textupdate", move |event: Event| {
+            if prevent_default.get() {
+                event.prevent_default();
+            }
+            // `textupdate` fires on the EditContext object
+            // itself, not on the canvas. Pull text +
+            // updateRangeEnd off it via Reflect.
+            let edit_context = JsValue::from(event.target());
+            let text_update_event = JsValue::from(event);
+            let Ok(text) = Reflect::get(&text_update_event, &JsValue::from_str("text")) else {
+                return;
+            };
+            let Ok(update_range_end) =
+                Reflect::get(&text_update_event, &JsValue::from_str("updateRangeEnd"))
+            else {
+                return;
+            };
+
+            handler(text.as_string(), None);
+
+            // Clear the text update region so we don't get
+            // repeated updates for the same preedit. The
+            // EditContext API has no `commit()` — instead we
+            // call `updateText(0, end, "")` to consume what
+            // we just read.
+            if let Ok(func) = Reflect::get(&edit_context, &JsValue::from_str("updateText")) {
+                let func: &Function = func.unchecked_ref();
+                let _ = func.call3(
+                    &edit_context,
+                    &JsValue::from_f64(0.0),
+                    &JsValue::from_f64(update_range_end.as_f64().unwrap_or(0.0)),
+                    &JsValue::from_str(""),
+                );
+            }
+        });
+    }
+
+    pub(crate) fn is_support_edit_context(&self) -> bool {
+        self.common.raw_edit_context.is_some()
+    }
+
+    pub(crate) fn enable_edit_context(&self) {
+        if let Some(raw_edit_context) = &self.common.raw_edit_context {
+            let canvas_js = JsValue::from(self.common.raw.deref());
+            let _ = Reflect::set(&canvas_js, &JsValue::from_str("editContext"), raw_edit_context);
+        }
+    }
+
+    pub(crate) fn disable_edit_context(&self) {
+        if self.common.raw_edit_context.is_none() {
+            return;
+        }
+        let canvas_js = JsValue::from(self.common.raw.deref());
+        let _ = Reflect::set(&canvas_js, &JsValue::from_str("editContext"), &JsValue::NULL);
+    }
+
+    /// Tell the EditContext where the text cursor lives so the
+    /// browser places its IME candidate window next to it. The
+    /// `(x, y)` is in iced canvas-local logical pixels — we
+    /// translate to viewport coords by adding the canvas's
+    /// position via `getBoundingClientRect`. Without this the
+    /// browser defaults to the bottom-left of the canvas.
+    pub(crate) fn update_character_bounds(&self, x: f64, y: f64, width: f64, height: f64) {
+        let Some(edit_context) = self.common.raw_edit_context.as_ref() else {
+            return;
+        };
+        let canvas_rect = self.common.raw.get_bounding_client_rect();
+        let vp_x = canvas_rect.x() + x;
+        let vp_y = canvas_rect.y() + y;
+        let Ok(rect) =
+            web_sys::DomRect::new_with_x_and_y_and_width_and_height(vp_x, vp_y, width, height)
+        else {
+            return;
+        };
+        let bounds = Array::new();
+        bounds.push(&rect);
+        let edit_context_js: &JsValue = edit_context.deref();
+        let Ok(update_fn) =
+            Reflect::get(edit_context_js, &JsValue::from_str("updateCharacterBounds"))
+        else {
+            return;
+        };
+        let update_fn: &Function = update_fn.unchecked_ref();
+        let _ = update_fn.call2(edit_context_js, &JsValue::from_f64(0.0), &bounds);
+    }
+
     pub fn request_fullscreen(&self) {
         fullscreen::request_fullscreen(self.document(), self.raw());
     }
@@ -515,6 +659,9 @@ impl Canvas {
         self.animation_frame_handler.cancel();
         self.on_touch_end = None;
         self.on_context_menu = None;
+        self.on_composition_start = None;
+        self.on_composition_end = None;
+        self.on_text_update = None;
     }
 }
 
@@ -529,6 +676,24 @@ impl Common {
         F: 'static + FnMut(E),
     {
         EventListenerHandle::new(self.raw.deref().clone(), event_name, Closure::new(handler))
+    }
+
+    /// Attach an event listener to the owned `EditContext` rather
+    /// than the canvas. Returns `None` if the browser doesn't
+    /// support EditContext — IME just stays unavailable in that
+    /// case (Safari, Firefox).
+    pub fn add_ime_event<E, F>(
+        &self,
+        event_name: &'static str,
+        handler: F,
+    ) -> Option<EventListenerHandle<dyn FnMut(E)>>
+    where
+        E: 'static + AsRef<web_sys::Event> + wasm_bindgen::convert::FromWasmAbi,
+        F: 'static + FnMut(E),
+    {
+        let edit_context = self.raw_edit_context.as_ref()?.deref().clone();
+        let target: EventTarget = edit_context.unchecked_into();
+        Some(EventListenerHandle::new(target, event_name, Closure::new(handler)))
     }
 
     pub fn raw(&self) -> &HtmlCanvasElement {

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -35,6 +35,7 @@ pub struct Canvas {
     id: WindowId,
     pub has_focus: Rc<Cell<bool>>,
     pub prevent_default: Rc<Cell<bool>>,
+    pub composing: Rc<Cell<bool>>,
     pub is_intersecting: Option<bool>,
     on_touch_start: Option<EventListenerHandle<dyn FnMut(Event)>>,
     on_focus: Option<EventListenerHandle<dyn FnMut(FocusEvent)>>,
@@ -62,8 +63,8 @@ pub struct Common {
     /// the DPI factor is maintained. Note: this is read-only because we use a pointer to this
     /// for [`WindowHandle`][rwh_06::WindowHandle].
     raw: Rc<HtmlCanvasElement>,
-    /// Owned `EditContext` instance, if the browser supports it
-    /// (Chromium 121+). When `Some`, IME events are routed through
+    /// Owned `EditContext` instance, if the browser supports it.
+    /// When `Some`, IME events are routed through
     /// it instead of through canvas keyboard events, which lets
     /// the OS IME composition (CJK, Indic, etc.) hand committed
     /// text into a wgpu canvas. `None` on non-Chromium browsers
@@ -123,8 +124,8 @@ impl Canvas {
 
         let cursor = CursorHandler::new(main_thread, canvas.clone(), style.clone());
 
-        // Optional EditContext for IME (Chromium 121+). Other
-        // browsers leave this `None` and IME stays unavailable.
+        // Optional EditContext for IME, for browser that support it. On other browsers,
+        // IME is simply not available.
         let edit_context = Reflect::get(&window, &JsValue::from_str("EditContext"))
             .ok()
             .filter(|v| !v.is_undefined())
@@ -176,6 +177,7 @@ impl Canvas {
             id,
             has_focus: Rc::new(Cell::new(false)),
             prevent_default: Rc::new(Cell::new(attr.platform_specific.prevent_default)),
+            composing: Rc::new(Cell::new(false)),
             is_intersecting: None,
             on_touch_start: None,
             on_blur: None,
@@ -299,8 +301,12 @@ impl Canvas {
         F: 'static + FnMut(PhysicalKey, Key, Option<SmolStr>, KeyLocation, bool, ModifiersState),
     {
         let prevent_default = Rc::clone(&self.prevent_default);
+        let composing = Rc::clone(&self.composing);
         self.on_keyboard_release =
             Some(self.common.add_event("keyup", move |event: KeyboardEvent| {
+                if composing.get() || is_ime_composing(&event) {
+                    return;
+                }
                 if prevent_default.get() {
                     event.prevent_default();
                 }
@@ -322,8 +328,13 @@ impl Canvas {
         F: 'static + FnMut(PhysicalKey, Key, Option<SmolStr>, KeyLocation, bool, ModifiersState),
     {
         let prevent_default = Rc::clone(&self.prevent_default);
+        let composing = Rc::clone(&self.composing);
         self.on_keyboard_press =
             Some(self.common.add_event("keydown", move |event: KeyboardEvent| {
+                let suppress = composing.get() || is_ime_composing(&event);
+                if suppress {
+                    return;
+                }
                 if prevent_default.get() {
                     event.prevent_default();
                 }
@@ -471,8 +482,10 @@ impl Canvas {
         F: 'static + FnMut(Option<String>, Option<(usize, usize)>),
     {
         let prevent_default = Rc::clone(&self.prevent_default);
+        let composing = Rc::clone(&self.composing);
         self.on_composition_start =
             self.common.add_ime_event("compositionstart", move |event: CompositionEvent| {
+                composing.set(true);
                 if prevent_default.get() {
                     event.prevent_default();
                 }
@@ -485,8 +498,10 @@ impl Canvas {
         F: 'static + FnMut(Option<String>),
     {
         let prevent_default = Rc::clone(&self.prevent_default);
+        let composing = Rc::clone(&self.composing);
         self.on_composition_end =
             self.common.add_ime_event("compositionend", move |event: CompositionEvent| {
+                composing.set(false);
                 if prevent_default.get() {
                     event.prevent_default();
                 }
@@ -503,36 +518,11 @@ impl Canvas {
             if prevent_default.get() {
                 event.prevent_default();
             }
-            // `textupdate` fires on the EditContext object
-            // itself, not on the canvas. Pull text +
-            // updateRangeEnd off it via Reflect.
-            let edit_context = JsValue::from(event.target());
             let text_update_event = JsValue::from(event);
-            let Ok(text) = Reflect::get(&text_update_event, &JsValue::from_str("text")) else {
-                return;
-            };
-            let Ok(update_range_end) =
-                Reflect::get(&text_update_event, &JsValue::from_str("updateRangeEnd"))
-            else {
-                return;
-            };
-
-            handler(text.as_string(), None);
-
-            // Clear the text update region so we don't get
-            // repeated updates for the same preedit. The
-            // EditContext API has no `commit()` — instead we
-            // call `updateText(0, end, "")` to consume what
-            // we just read.
-            if let Ok(func) = Reflect::get(&edit_context, &JsValue::from_str("updateText")) {
-                let func: &Function = func.unchecked_ref();
-                let _ = func.call3(
-                    &edit_context,
-                    &JsValue::from_f64(0.0),
-                    &JsValue::from_f64(update_range_end.as_f64().unwrap_or(0.0)),
-                    &JsValue::from_str(""),
-                );
-            }
+            let text = Reflect::get(&text_update_event, &JsValue::from_str("text"))
+                .ok()
+                .and_then(|v| v.as_string());
+            handler(text, None);
         });
     }
 
@@ -555,27 +545,58 @@ impl Canvas {
         let _ = Reflect::set(&canvas_js, &JsValue::from_str("editContext"), &JsValue::NULL);
     }
 
-    /// Tell the EditContext where the text cursor lives so the
-    /// browser places its IME candidate window next to it. The
-    /// `(x, y)` is in iced canvas-local logical pixels — we
-    /// translate to viewport coords by adding the canvas's
-    /// position via `getBoundingClientRect`. Without this the
-    /// browser defaults to the bottom-left of the canvas.
     pub(crate) fn update_character_bounds(&self, x: f64, y: f64, width: f64, height: f64) {
+        const BOUNDS_RANGE: usize = 64;
+
         let Some(edit_context) = self.common.raw_edit_context.as_ref() else {
             return;
         };
         let canvas_rect = self.common.raw.get_bounding_client_rect();
         let vp_x = canvas_rect.x() + x;
         let vp_y = canvas_rect.y() + y;
-        let Ok(rect) =
-            web_sys::DomRect::new_with_x_and_y_and_width_and_height(vp_x, vp_y, width, height)
-        else {
-            return;
-        };
-        let bounds = Array::new();
-        bounds.push(&rect);
         let edit_context_js: &JsValue = edit_context.deref();
+
+        // Chromium positions the IME candidate window primarily off
+        // `updateSelectionBounds`, then `updateControlBounds`, then
+        // (only if both are unset) the per-character bounds set via
+        // `updateCharacterBounds`. We push all three so the candidate
+        // window lands next to the caret regardless of which one the
+        // browser version prefers.
+        let caret_rect = match web_sys::DomRect::new_with_x_and_y_and_width_and_height(
+            vp_x, vp_y, width, height,
+        ) {
+            Ok(rect) => rect,
+            Err(_) => return,
+        };
+
+        if let Ok(f) = Reflect::get(edit_context_js, &JsValue::from_str("updateSelectionBounds")) {
+            let f: &Function = f.unchecked_ref();
+            let _ = f.call1(edit_context_js, &caret_rect);
+        }
+
+        let control_rect = match web_sys::DomRect::new_with_x_and_y_and_width_and_height(
+            canvas_rect.x(),
+            canvas_rect.y(),
+            canvas_rect.width(),
+            canvas_rect.height(),
+        ) {
+            Ok(rect) => rect,
+            Err(_) => return,
+        };
+        if let Ok(f) = Reflect::get(edit_context_js, &JsValue::from_str("updateControlBounds")) {
+            let f: &Function = f.unchecked_ref();
+            let _ = f.call1(edit_context_js, &control_rect);
+        }
+
+        let bounds = Array::new();
+        for _ in 0..BOUNDS_RANGE {
+            let Ok(rect) =
+                web_sys::DomRect::new_with_x_and_y_and_width_and_height(vp_x, vp_y, width, height)
+            else {
+                return;
+            };
+            bounds.push(&rect);
+        }
         let Ok(update_fn) =
             Reflect::get(edit_context_js, &JsValue::from_str("updateCharacterBounds"))
         else {
@@ -678,10 +699,6 @@ impl Common {
         EventListenerHandle::new(self.raw.deref().clone(), event_name, Closure::new(handler))
     }
 
-    /// Attach an event listener to the owned `EditContext` rather
-    /// than the canvas. Returns `None` if the browser doesn't
-    /// support EditContext — IME just stays unavailable in that
-    /// case (Safari, Firefox).
     pub fn add_ime_event<E, F>(
         &self,
         event_name: &'static str,
@@ -727,4 +744,8 @@ impl Style {
     pub(crate) fn set(&self, property: &str, value: &str) {
         self.write.set_property(property, value).expect("Property is read only");
     }
+}
+
+fn is_ime_composing(event: &KeyboardEvent) -> bool {
+    event.is_composing() || event.key_code() == 229
 }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -324,13 +324,29 @@ impl Inner {
     }
 
     #[inline]
-    pub fn set_ime_cursor_area(&self, _position: Position, _size: Size) {
-        // Currently a no-op as it does not seem there is good support for this on web
+    pub fn set_ime_cursor_area(&self, position: Position, size: Size) {
+        let scale = self.scale_factor();
+        let position = position.to_logical::<f64>(scale);
+        let size = size.to_logical::<f64>(scale);
+        self.canvas.borrow().update_character_bounds(
+            position.x,
+            position.y,
+            size.width,
+            size.height,
+        );
     }
 
     #[inline]
-    pub fn set_ime_allowed(&self, _allowed: bool) {
-        // Currently not implemented
+    pub fn set_ime_allowed(&self, allowed: bool) {
+        let canvas = self.canvas.borrow();
+        if !canvas.is_support_edit_context() {
+            return;
+        }
+        if allowed {
+            canvas.enable_edit_context();
+        } else {
+            canvas.disable_edit_context();
+        }
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1275,7 +1275,8 @@ impl Window {
     /// - **macOS:** IME must be enabled to receive text-input where dead-key sequences are
     ///   combined.
     /// - **iOS / Android:** This will show / hide the soft keyboard.
-    /// - **Web / Orbital:** Unsupported.
+    /// - **Web**: Supported on browsers implementing the [EditContext API](https://developer.mozilla.org/en-US/docs/Web/API/EditContext_API).
+    /// - **Orbital:** Unsupported.
     /// - **X11**: Enabling IME will disable dead keys reporting during compose.
     ///
     /// [`Ime`]: crate::event::WindowEvent::Ime


### PR DESCRIPTION
IME is not supported in winit on the web platform. This PR ports this one from upstream: https://github.com/rust-windowing/winit/pull/4428, by adding IME support thanks to the EditContext API. 

The EditContext API is not supported by all browser (only chromium actually, as of today), so on other browsers, it's noop. This is not ideal, but it's better than no support at all, and chromium has 80% market share anyways.

I'm creating the PR here, because I'm using iced, but he hope is that it can eventually make it upstream.

IIUC, the raison d'etre of this fork is to support URI handling on macos, which should be doable as soon as 0.31 is release, according to https://github.com/rust-windowing/winit/issues/2190#issuecomment-2945526451.

I'll also try to get the needle moving upstream, so that the fork doesn't diverge for too long.
